### PR TITLE
Update utilities emissions docs

### DIFF
--- a/net-emissions-token-network/README.md
+++ b/net-emissions-token-network/README.md
@@ -2,7 +2,7 @@
 
 The (net) emissions tokens network is a blockchain network for recording and trading the emissions from different channels such as the [utility emissions channel](https://wiki.hyperledger.org/display/CASIG/Utility+Emissions+Channel), plus offsetting Renewable Energy Certificates and carbon offsets. Each token represents either an emissions debt, which you incur through activities that emit greenhouse gases, or an emissions credit, which offset the debt by removing emissions from the atmosphere.
 
-Read more on the [Hyperledger Emissions Tokens Network Wiki page](https://wiki.hyperledger.org/display/CASIG/Emissions+Tokens+Network).
+Read more on the [Hyperledger Emissions Tokens Network Wiki page](https://wiki.hyperledger.org/display/CASIG/Emissions+Tokens+Network+Project).
 
 To see a demo of how it works, check out [this video](https://youtu.be/C-cUjQLDGJw).
 

--- a/net-emissions-token-network/README.md
+++ b/net-emissions-token-network/README.md
@@ -1,6 +1,6 @@
 # Net Emissions Tokens Network
 
-The (net) emissions tokens network is a blockchain network for recording and trading the emissions from different channels such as the [utility emissions channel](https://wiki.hyperledger.org/display/CASIG/Utility+Emissions+Channel), plus offsetting Renewable Energy Certificates and carbon offsets. Each token represents either an emissions debt, which you incur through activities that emit greenhouse gases, or an emissions credit, which offset the debt by removing emissions from the atmosphere.
+The (net) emissions tokens network is a blockchain network for recording and trading the emissions from different channels such as the [utility emissions channel](https://wiki.hyperledger.org/display/CASIG/Utility+Emissions+Channel+Project), plus offsetting Renewable Energy Certificates and carbon offsets. Each token represents either an emissions debt, which you incur through activities that emit greenhouse gases, or an emissions credit, which offset the debt by removing emissions from the atmosphere.
 
 Read more on the [Hyperledger Emissions Tokens Network Wiki page](https://wiki.hyperledger.org/display/CASIG/Emissions+Tokens+Network+Project).
 

--- a/net-emissions-token-network/docs/using-the-react-application.md
+++ b/net-emissions-token-network/docs/using-the-react-application.md
@@ -15,7 +15,7 @@ The application connects to the contract of the address specified in `net-emissi
 
 ## Installation
 
-From the `net-emissions.token-network/interface` directory, run
+From the `net-emissions-token-network/interface` directory, run
 
 ```bash
 yarn install

--- a/utility-emissions-channel/README.md
+++ b/utility-emissions-channel/README.md
@@ -4,7 +4,7 @@ This project implements the [Utility Emissions Channel](https://wiki.hyperledger
 
 ## Running the Fabric network and Express API
 
-1. Make sure you have Git, curl, Docker, and Docker Compose installed, or follow instructions from [Hyperledger Fabric Install Prerequisites](https://hyperledger-fabric.readthedocs.io/en/release-2.2/prereqs.html)
+1. Make sure you have Git, cURL, Docker, and Docker Compose installed, or follow instructions from [Hyperledger Fabric Install Prerequisites](https://hyperledger-fabric.readthedocs.io/en/release-2.2/prereqs.html)
 2. From `utility-emissions-channel/`, copy over the Amazon Web Services (AWS) configuration template file with:
 
 ```bash
@@ -37,6 +37,14 @@ $ cp ./typescript_app/src/config/networkConfig.ts.example ./typescript_app/src/c
     export const INFURA_PROJECT_SECRET = "infura_secret";
 ```
 
+For the above you may need to start a new [Infura](https://infura.io/) project and use the credentials there for the project id and secret. 
+Regarding the Ethereum dealer wallet you will need for the private key, one option is [MetaMask](https://metamask.io/) which offers a handy Chrome extension.
+Moreover, you may also need to create a Goerli TestNet wallet. Detailed instructions regarding how to set this up can be found for example at [the Mudit blog](https://mudit.blog/getting-started-goerli-testnet/).
+We already have smart contracts under [net-emissions-token](https://github.com/hyperledger-labs/blockchain-carbon-accounting/blob/4a8c8c916127bdabed7734074fb9ae78e44e27cc/net-emissions-token-network/README.md) network.
+The Express API that connects to ethereum will call that to create emissions tokens. Please check the instructions for the `net-emissions-token-network` [here](https://github.com/hyperledger-labs/blockchain-carbon-accounting/blob/4a8c8c916127bdabed7734074fb9ae78e44e27cc/net-emissions-token-network/docs/using-the-react-application.md).
+Note for the `CONTRACT_ADDRESS` you can use the address of Ethereum contract required to connect to on the Goerli testnet, this can be found in the Settings section of your Infura project. 
+In particular, checkout the section "With Goerli testnet" below after following the instructions for installing the React application above therein. 
+
 6.  Install the right binaries.  You will need the linux binaries to run inside of docker, as well as the binaries for your operating system.
 
 ```bash
@@ -66,8 +74,14 @@ $ npm install
 
 8.  From `utilities-emissions-channel/docker-compose-setup`, run the start script (includes the reset script which resets the Fabric state):
 
-Start network, create channel, and deployCC:
+### Start network, create channel, and deployCC
 
+If you are doing it for the first time, run:
+```bash
+sh start.sh
+```
+
+Otherwise, run:
 ```bash
 sh ./scripts/reset.sh && sh start.sh
 ```

--- a/utility-emissions-channel/README.md
+++ b/utility-emissions-channel/README.md
@@ -5,13 +5,14 @@ This project implements the [Utility Emissions Channel](https://wiki.hyperledger
 ## Running the Fabric network and Express API
 
 1. Make sure you have Git, cURL, Docker, and Docker Compose installed, or follow instructions from [Hyperledger Fabric Install Prerequisites](https://hyperledger-fabric.readthedocs.io/en/release-2.2/prereqs.html)
-2. From `utility-emissions-channel/`, copy over the Amazon Web Services (AWS) configuration template file with:
+
+2. From `utility-emissions-channel`, copy over the Fabric network configuration settings template file with:
 
 ```bash
 $ cp ./typescript_app/src/config/config.ts.example ./typescript_app/src/config/config.ts
 ```
 
-From utility-emissions-channel/, copy over the Amazon Web Services (AWS) configuration template file with:
+3. From `utility-emissions-channel`, copy over the Amazon Web Services (AWS) configuration template file with:
 ```bash
 $ cp ./typescript_app/src/config/aws-config.js.template ./typescript_app/src/config/aws-config.js
 ```


### PR DESCRIPTION
Fixes #98.

Add info to provide context for setting up `utility-emissions-channel`, especially for the instructions up top for [Running the Fabric network and Express API](https://github.com/hyperledger-labs/blockchain-carbon-accounting/tree/main/utility-emissions-channel#running-the-fabric-network-and-express-api). This is in order to help the user to set the Ethereum configuration settings properly. 