### PR TITLE
add fabricNetwork.sh ; stop and restart fabric network for dev

### DIFF
--- a/utility-emissions-channel/docker-compose-setup/scripts/fabricNetwork.sh
+++ b/utility-emissions-channel/docker-compose-setup/scripts/fabricNetwork.sh
@@ -1,0 +1,31 @@
+# /bin/bash
+# script for stoping and restarting fabric network
+# helpful in development
+
+CMD=$1
+DOCKERE_CMD=stop
+case $CMD in
+    "stop")
+        DOCKERE_CMD=stop
+        docker stop cli
+    ;;
+    "resume")
+        DOCKERE_CMD=restart
+        ./scripts/startCli.sh
+    ;;
+    *)
+        echo "command $CMD not supported"
+        exit 1
+    ;;
+esac
+
+docker-compose \
+    -f ./docker/nodes/node-one/docker-compose-ca.yaml \
+    -f ./docker/nodes/node-two/docker-compose-ca.yaml \
+    -f ./docker/nodes/node-one/docker-compose-couch.yaml \
+    -f ./docker/nodes/node-one/docker-compose-carbonAccounting.yaml \
+    -f ./docker/nodes/node-two/docker-compose-couch.yaml \
+    -f ./docker/nodes/node-two/docker-compose-carbonAccounting.yaml \
+    -f ./docker/nodes/node-one/docker-compose-chaincode.yaml \
+    -f ./docker/nodes/node-two/docker-compose-chaincode.yaml \
+    $DOCKERE_CMD


### PR DESCRIPTION
For development start fabric network only once. then use 
`./.scripts/fabricNetwork.sh stop`  : to stop the fabric network
`./scripts/fabricNetwork.sh resume` : to restart fabric network from previous run.

Signed-off-by: Pritam Singh <pkspritam16@gmail.com>