### PR TITLE
Encrypt partyId with AES and remove SHA-256 hash

### DIFF
--- a/utility-emissions-channel/chaincode/typescript/src/lib/emissionsRecordContract.ts
+++ b/utility-emissions-channel/chaincode/typescript/src/lib/emissionsRecordContract.ts
@@ -2,7 +2,7 @@ import { ChaincodeStub } from 'fabric-shim';
 import { EmissionRecordState, EmissionsRecord, EmissionsRecordInterface } from './emissions';
 import { getCO2EmissionFactor } from './emissions-calc';
 import { UtilityEmissionsFactor, UtilityEmissionsFactorInterface, UtilityEmissionsFactorState } from './utilityEmissionsFactor';
-import {MD5, SHA256} from 'crypto-js';
+import { MD5 } from 'crypto-js';
 import {
   UtilityLookupItemInterface,
   UtilityLookupItemState,
@@ -39,12 +39,11 @@ export class EmissionsRecordContract {
 
       // create an instance of the emissions record
       const uuid = MD5(utilityId + partyId + fromDate + thruDate).toString();
-      const partyIdsha256 = SHA256(partyId).toString();
 
       const emissionI:EmissionsRecordInterface = {
         uuid,
         utilityId,
-        partyId: partyIdsha256,
+        partyId,
         fromDate,
         thruDate,
         emissionsAmount: co2Emission.emission.value,
@@ -62,9 +61,6 @@ export class EmissionsRecordContract {
   }
 
   async updateEmissionsRecord(recordI:EmissionsRecordInterface):Promise<Uint8Array>{
-    if (recordI['partyId']) {
-        recordI['partyId'] = SHA256(recordI['partyId']).toString();
-    }
     const record = new EmissionsRecord(recordI);
     await this.emissionsState.updateEmissionsRecord(record,recordI.uuid);
     return record.toBuffer();
@@ -74,8 +70,7 @@ export class EmissionsRecordContract {
     return record.toBuffer();
   }
   async getAllEmissionsData(utilityId:string, partyId:string):Promise<Uint8Array>{
-    const partyIdsha256 = SHA256(partyId).toString();
-    const records = await this.emissionsState.getAllEmissionRecords(utilityId,partyIdsha256);
+    const records = await this.emissionsState.getAllEmissionRecords(utilityId,partyId);
     return Buffer.from(JSON.stringify(records));
   }
   async getAllEmissionsDataByDateRange(fromDate:string, thruDate:string):Promise<Uint8Array>{
@@ -83,8 +78,7 @@ export class EmissionsRecordContract {
     return Buffer.from(JSON.stringify(records));
   }
   async getAllEmissionsDataByDateRangeAndParty(fromDate:string, thruDate:string, partyId:string):Promise<Uint8Array>{
-    const partyIdsha256 = SHA256(partyId).toString();
-    const records = await this.emissionsState.getAllEmissionsDataByDateRangeAndParty(fromDate,thruDate,partyIdsha256);
+    const records = await this.emissionsState.getAllEmissionsDataByDateRangeAndParty(fromDate,thruDate,partyId);
     return Buffer.from(JSON.stringify(records));
   }
   async importUtilityFactor(factorI:UtilityEmissionsFactorInterface){

--- a/utility-emissions-channel/typescript_app/package-lock.json
+++ b/utility-emissions-channel/typescript_app/package-lock.json
@@ -942,6 +942,12 @@
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
       "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog=="
     },
+    "@types/crypto-js": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.0.2.tgz",
+      "integrity": "sha512-sCVniU+h3GcGqxOmng11BRvf9TfN9yIs8KKjB8C8d75W69cpTfZG80gau9yTx5SxF3gvHGbJhdESzzvnjtf3Og==",
+      "dev": true
+    },
     "@types/express": {
       "version": "4.17.8",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.8.tgz",
@@ -1827,6 +1833,11 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "crypto-random-string": {
       "version": "2.0.0",

--- a/utility-emissions-channel/typescript_app/package.json
+++ b/utility-emissions-channel/typescript_app/package.json
@@ -22,6 +22,7 @@
     "chai": "^4.2.0",
     "chai-http": "^4.3.0",
     "chalk": "^4.1.0",
+    "crypto-js": "^4.1.1",
     "dotenv": "^8.2.0",
     "ethers": "^5.0.24",
     "express": "^4.17.1",
@@ -36,6 +37,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
+    "@types/crypto-js": "^4.0.2",
     "serverless-s3-local": "^0.6.7"
   }
 }

--- a/utility-emissions-channel/typescript_app/src/routers/utilityEmissionsChannel/ivokeEmissionscontract.v0.ts
+++ b/utility-emissions-channel/typescript_app/src/routers/utilityEmissionsChannel/ivokeEmissionscontract.v0.ts
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import { AES } from "crypto-js";
 import express from "express";
 import { log } from "../../utils/log";
 import { body, param, validationResult } from "express-validator";
@@ -13,6 +14,7 @@ import {
 import { API_URL } from "../../config/config";
 
 const APP_VERSION = "v1";
+const PASSPHRASE = "secret passphrase";
 export const router = express.Router();
 
 // http://localhost:9000/api/v1//utilityemissionchannel/emissionscontract/recordEmissions
@@ -58,7 +60,7 @@ router.post(
       const userId = req.body.userId;
       const orgName = req.body.orgName;
       const utilityId = req.body.utilityId;
-      const partyId = req.body.partyId;
+      const partyId = AES.encrypt(req.body.partyId, PASSPHRASE).toString();
       const fromDate = req.body.fromDate;
       const thruDate = req.body.thruDate;
       const energyUseAmount = req.body.energyUseAmount;
@@ -168,7 +170,7 @@ router.get(GET_ALL_EMISSIONS_DATA, [param("userId").isString(), param("orgName")
     const userId = req.params.userId;
     const orgName = req.params.orgName;
     const utilityId = req.params.utilityId;
-    const partyId = req.params.partyId;
+    const partyId = AES.encrypt(req.params.partyId, PASSPHRASE).toString();
 
     console.log(`# GETTING EMISSIONS DATA FROM UTILITYEMISSIONS CHANNEL`);
 
@@ -265,11 +267,11 @@ export const RECORD_AUDITED_EMISSIONS_TOKEN =
 router.post(
   RECORD_AUDITED_EMISSIONS_TOKEN,
   [
-      body("userId").isString(),
-      body("orgName").isString(),
-      body("partyId").isString(),
-      body("addressToIssue").isString(),
-      body("emissionsRecordsToAudit").isString(),
+    body("userId").isString(),
+    body("orgName").isString(),
+    body("partyId").isString(),
+    body("addressToIssue").isString(),
+    body("emissionsRecordsToAudit").isString(),
   ],
   async (req, res) => {
     const errors = validationResult(req);
@@ -279,7 +281,7 @@ router.post(
     try {
       const userId = req.body.userId;
       const orgName = req.body.orgName;
-      const partyId = req.body.partyId;
+      const partyId = AES.encrypt(req.body.partyId, PASSPHRASE).toString();
       const addressToIssue = req.body.addressToIssue;
       const emissionsRecordsToAudit = req.body.emissionsRecordsToAudit.toString().split(",");
       // @TODO: use automaticRetireDate parameter


### PR DESCRIPTION
This PR fixes #263  
- [x] Encrypt the partyId with AES cipher algorithm in the typescript_app when invoking the chaincode function recordEmission. The secret passphrase needs to be stored in the middleware.
- [x] Remove all functions that calculate the hash value of the partyId from the chaincode

Initially for this PR, as @udosson suggested, I am using a constant passphrase.