### PR TITLE
feat(CI): add GitHub Actions pipeline for E2E tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,11 @@ jobs:
       - name: Build utility-emissions-channel project
         run: |
           cd docker-compose-setup/
+          echo "127.0.0.1       auditor1.carbonAccounting.com
+          127.0.0.1       auditor2.carbonAccounting.com
+          127.0.0.1       peer1.auditor1.carbonAccounting.com
+          127.0.0.1       peer1.auditor2.carbonAccounting.com
+          127.0.0.1       peer1.auditor1.carbonAccounting.com" | sudo tee -a /etc/hosts
           ./start.sh &
       - name: Run tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: End-to-end tests
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./utility-emissions-channel
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12.15.0'
+      - name: Download Fabric binaries and Docker compose
+        run: |
+          sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+          cd docker-compose-setup/
+          ./bootstrap.sh  2.2.1 1.4.9 -d -s
+      - name: Start local Hardhat network
+        run: |
+          cd ../net-emissions-token-network/
+          npm i -g npm@7.24.1
+          npm ci
+          npx hardhat node --show-accounts &
+      - name: Build utility-emissions-channel project
+        run: |
+          cd docker-compose-setup/
+          ./start.sh
+      - name: Run tests
+        run: |
+          cd typescript_app/
+          npm ci
+          npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,8 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '12.15.0'
-      - name: Download Fabric binaries and Docker compose
+      - name: Download Fabric binaries
         run: |
-          sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
           cd docker-compose-setup/
           ./bootstrap.sh  2.2.1 1.4.9 -d -s
@@ -27,13 +26,14 @@ jobs:
           cd ../net-emissions-token-network/
           npm i -g npm@7.24.1
           npm ci
-          npx hardhat node --show-accounts &
+          echo "n" | npx hardhat node --show-accounts &
       - name: Build utility-emissions-channel project
         run: |
           cd docker-compose-setup/
-          ./start.sh
+          ./start.sh &
       - name: Run tests
         run: |
+          sleep 240
+          docker ps -a
           cd typescript_app/
-          npm ci
           npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,6 @@ jobs:
       - name: Run tests
         run: |
           sleep 240
-          docker ps -a
           cd typescript_app/
+          npm run test:setup
           npm run test

--- a/utility-emissions-channel/README.md
+++ b/utility-emissions-channel/README.md
@@ -308,6 +308,12 @@ $ cd ../net-emissions-token-network/
 $ npm install
 $ npx hardhat node --show-accounts
 ```
+
+If you are running the tests for the first time, run the test setup script after navigating to the `typescript_app` directory. This inserts mock data and configures the Vault server for testing.
+```bash
+$ npm run test:setup
+```
+
 When the network/API and the local Hardhat network have fully started, you can run the automated tests by navigating to the `typescript_app` directory and running the tests as:
 
 

--- a/utility-emissions-channel/docker-compose-setup/start.sh
+++ b/utility-emissions-channel/docker-compose-setup/start.sh
@@ -10,27 +10,27 @@ echo "Starting client..."
 ./scripts/startCli.sh
 
 echo "Generating crpyto and orgs..."
-docker exec -it cli /bin/bash ./network.sh up
+docker exec cli /bin/bash ./network.sh up
 
 echo "Starting orderers, peers, and couchdb..."
 sh ./scripts/startAndConnectNetwork.sh
 
 echo "Creating the channel..."
-docker exec -it cli /bin/bash ./network.sh createChannel
+docker exec cli /bin/bash ./network.sh createChannel
 
 echo "Install ext chaincode..."
-docker exec -it cli /bin/bash ./scripts/installChaincode.sh 1 2
-docker exec -it cli /bin/bash ./scripts/installChaincode.sh 1 1
+docker exec cli /bin/bash ./scripts/installChaincode.sh 1 2
+docker exec cli /bin/bash ./scripts/installChaincode.sh 1 1
 
 echo "Starting ext chaincode..."
 sh ./scripts/startExtChaincode.sh
 
 echo "Deploying CC Ext..."
-docker exec -it cli /bin/bash ./scripts/deployCCExt.sh 1 1
-docker exec -it cli /bin/bash ./scripts/deployCCExt.sh 1 2
+docker exec cli /bin/bash ./scripts/deployCCExt.sh 1 1
+docker exec cli /bin/bash ./scripts/deployCCExt.sh 1 2
 
 sleep 20
-docker exec -it cli /bin/bash ./scripts/commitCCExt.sh 1 1
+docker exec cli /bin/bash ./scripts/commitCCExt.sh 1 1
 
 echo "Starting the api..."
 ./scripts/startApi.sh $1


### PR DESCRIPTION
Signed-off-by: Harsh Sharma <bcs_2019023@iiitm.ac.in>

This PR fixes #209.

Added a GitHub actions workflow to run the end-to-end tests for the project every time a new PR is opened or a new commit is pushed onto the main branch. I have followed the same setup instructions as given in the README, with the exception of uploading the seed data, as the E2E tests already account for that. However, the CI is failing in the step where the API needs to be started, as described [here](https://github.com/hyperledger-labs/blockchain-carbon-accounting/issues/209#issuecomment-927253339).