### PR TITLE
Updated tests for FabricSigningCredentialType.WsX509

### DIFF
--- a/utility-emissions-channel/typescript_app/src/blockchain-gateway/I-gateway.ts
+++ b/utility-emissions-channel/typescript_app/src/blockchain-gateway/I-gateway.ts
@@ -7,8 +7,12 @@ export interface IFabricTxCaller {
     vaultToken?: string;
     // require if server is using web-socket
     // key session id its siganture to access ws-wallet signer
-    wsSessionId?: string;
-    wsSidSig?: string;
+    webSocketKey?: IWebSocketKey;
+}
+
+export interface IWebSocketKey {
+    sessionId: string;
+    signature: string;
 }
 
 // ##############################################################

--- a/utility-emissions-channel/typescript_app/src/blockchain-gateway/signer.ts
+++ b/utility-emissions-channel/typescript_app/src/blockchain-gateway/signer.ts
@@ -47,27 +47,24 @@ export default class Signer {
                 token: caller.vaultToken,
                 keyName: caller.userId,
             };
-        } else if (this.hlfSupport.includes('web-socket') && caller.wsSessionId) {
-            if (caller.wsSessionId.length === 0) {
+        } else if (this.hlfSupport.includes('web-socket') && caller.webSocketKey) {
+            if (caller.webSocketKey['sessionId'].length === 0) {
                 throw new ClientError(
                     `${fnTag} require web-socket session ID to sign fabric transactions with ws-wallet`,
                 );
             }
-            if (!caller.wsSidSig || caller.wsSidSig.length === 0) {
+            if (caller.webSocketKey['signature'].length === 0) {
                 throw new ClientError(
                     `${fnTag} require web-socket session ID signature to sign fabric transactions with ws-wallet`,
                 );
             }
             signer.type = FabricSigningCredentialType.WsX509;
-            signer.webSocketKey = {
-                sessionId: caller.wsSessionId,
-                signature: caller.wsSidSig,
-            };
+            signer.webSocketKey = caller.webSocketKey;
         } else {
             throw new ClientError(
                 `${fnTag} missing ${this.hlfSupport
                     .split(' ')
-                    .join('or')} API keys to sign fabric transactions`,
+                    .join(' or ')} API keys to sign fabric transactions`,
             );
         }
         return signer;

--- a/utility-emissions-channel/typescript_app/src/controllers/registerEnroll.ts
+++ b/utility-emissions-channel/typescript_app/src/controllers/registerEnroll.ts
@@ -5,9 +5,10 @@ export async function enroll(req: Request, res: Response): Promise<void> {
     try {
         await fabricRegistryService.enroll({
             body: req.body,
-            header: req.headers as Record<string, string>,
+            header: req.headers as Record<string, string | unknown>,
             query: req.query as Record<string, string>,
         });
+
         res.status(201).send();
     } catch (error) {
         res.status(error.status).json({
@@ -20,7 +21,7 @@ export async function register(req: Request, res: Response): Promise<void> {
     try {
         const cred = await fabricRegistryService.register({
             body: req.body,
-            header: req.headers as Record<string, string>,
+            header: req.headers as Record<string, string | unknown>,
             query: req.query as Record<string, string>,
         });
         res.status(201).json(cred);

--- a/utility-emissions-channel/typescript_app/src/controllers/utilityEmissionsChannel.ts
+++ b/utility-emissions-channel/typescript_app/src/controllers/utilityEmissionsChannel.ts
@@ -9,7 +9,7 @@ export async function recordEmission(req: Request, res: Response): Promise<void>
         }
         const record = await utilityEmissionsChannelService.recordEmission({
             body: req.body,
-            header: req.headers as Record<string, string>,
+            header: req.headers as Record<string, string | unknown>,
             query: req.query as Record<string, string>,
             file: file,
         });
@@ -25,7 +25,7 @@ export async function getEmissionsData(req: Request, res: Response): Promise<voi
     try {
         const record = await utilityEmissionsChannelService.getEmissionsData({
             body: req.body,
-            header: req.headers as Record<string, string>,
+            header: req.headers as Record<string, string | unknown>,
             query: req.query as Record<string, string>,
             params: req.params,
         });
@@ -41,7 +41,7 @@ export async function getAllEmissionsData(req: Request, res: Response): Promise<
     try {
         const record = await utilityEmissionsChannelService.getAllEmissionsData({
             body: req.body,
-            header: req.headers as Record<string, string>,
+            header: req.headers as Record<string, string | unknown>,
             query: req.query as Record<string, string>,
             params: req.params,
         });
@@ -57,7 +57,7 @@ export async function getAllEmissionsDataByDateRange(req: Request, res: Response
     try {
         const record = await utilityEmissionsChannelService.getAllEmissionsDataByDateRange({
             body: req.body,
-            header: req.headers as Record<string, string>,
+            header: req.headers as Record<string, string | unknown>,
             query: req.query as Record<string, string>,
             params: req.params,
         });
@@ -73,7 +73,7 @@ export async function recordAuditedEmissionsToken(req: Request, res: Response): 
     try {
         const record = await utilityEmissionsChannelService.recordAuditedEmissionsToken({
             body: req.body,
-            header: req.headers as Record<string, string>,
+            header: req.headers as Record<string, string | unknown>,
             query: req.query as Record<string, string>,
             params: req.params,
         });

--- a/utility-emissions-channel/typescript_app/src/routers/v1/index.ts
+++ b/utility-emissions-channel/typescript_app/src/routers/v1/index.ts
@@ -6,6 +6,9 @@ import identity from './identity';
 const router = Router();
 router.use((req: Request, res: Response, next: NextFunction) => {
     appLogger.info(`${req.method.toUpperCase()} ${req.url}`);
+    if (req.headers.web_socket_key) {
+        req.headers.web_socket_key = JSON.parse(`${req.headers.web_socket_key}`);
+    }
     next();
 });
 

--- a/utility-emissions-channel/typescript_app/src/service/fabricRegistry.ts
+++ b/utility-emissions-channel/typescript_app/src/service/fabricRegistry.ts
@@ -1,7 +1,7 @@
 import { Input } from './input';
 import Joi from 'joi';
 import ClientError from '../errors/clientError';
-import { IFabricRegistryGateway } from '../blockchain-gateway/I-gateway';
+import { IFabricRegistryGateway, IWebSocketKey } from '../blockchain-gateway/I-gateway';
 import { appLogger, ledgerLogger } from '../utils/logger';
 
 interface registerOutput {
@@ -15,14 +15,12 @@ export default class FabricRegistryService {
 
     async register(input: Input): Promise<registerOutput> {
         this.__validateRegister(input);
-        console.log(input.query.userId);
         try {
             const cred = await this.gateway.register(
                 {
                     userId: input.query.userId,
-                    vaultToken: input.header.vault_token,
-                    wsSessionId: input.header.session_id,
-                    wsSidSig: input.header.signature,
+                    vaultToken: input.header.vault_token as string,
+                    webSocketKey: input.header.web_socket_key as IWebSocketKey,
                 },
                 {
                     enrollmentID: input.body.enrollmentID,
@@ -44,9 +42,8 @@ export default class FabricRegistryService {
             await this.gateway.enroll(
                 {
                     userId: input.body.enrollmentID,
-                    vaultToken: input.header.vault_token,
-                    wsSessionId: input.header.session_id,
-                    wsSidSig: input.header.signature,
+                    vaultToken: input.header.vault_token as string,
+                    webSocketKey: input.header.web_socket_key as IWebSocketKey,
                 },
                 input.body.enrollmentSecret,
             );

--- a/utility-emissions-channel/typescript_app/src/service/input.ts
+++ b/utility-emissions-channel/typescript_app/src/service/input.ts
@@ -1,6 +1,6 @@
 export interface Input {
     body: Record<string, string>;
-    header: Record<string, string>;
+    header: Record<string, string | unknown>;
     query: Record<string, string>;
     file?: Buffer;
     params?: Record<string, string>;

--- a/utility-emissions-channel/typescript_app/src/service/utilityEmissionsChannel.ts
+++ b/utility-emissions-channel/typescript_app/src/service/utilityEmissionsChannel.ts
@@ -13,6 +13,7 @@ import AWSS3 from '../datasource/awsS3';
 import Joi from 'joi';
 import { createHash } from 'crypto';
 import { checkDateConflict, toTimestamp } from '../utils/dateUtils';
+import { IWebSocketKey } from '../blockchain-gateway/I-gateway';
 
 interface UtilityEmissionsChannelServiceOptions {
     utilityEmissionsGateway: IUtilityemissionchannelGateway;
@@ -54,9 +55,8 @@ export default class UtilityEmissionsChannelService {
 
         const fabricCaller: IFabricTxCaller = {
             userId: userId,
-            vaultToken: input.header.vault_token,
-            wsSessionId: input.header.session_id,
-            wsSidSig: input.header.signature,
+            vaultToken: input.header.vault_token as string,
+            webSocketKey: input.header.web_socket_key as IWebSocketKey,
         };
 
         try {
@@ -125,13 +125,12 @@ export default class UtilityEmissionsChannelService {
         this.__validateRecordAuditedEmissionsToken(input);
         const fabricCaller: IFabricTxCaller = {
             userId: input.query.userId,
-            vaultToken: input.header.vault_token,
-            wsSessionId: input.header.session_id,
-            wsSidSig: input.header.signature,
+            vaultToken: input.header.vault_token as string,
+            webSocketKey: input.header.web_socket_key as IWebSocketKey,
         };
         const ethCaller: IEthTxCaller = {
-            address: input.header.eth_address,
-            private: input.header.eth_private,
+            address: input.header.eth_address as string,
+            private: input.header.eth_private as string,
             keyName: input.query.userId,
         };
         const partyId = input.body.partyId;
@@ -271,9 +270,8 @@ export default class UtilityEmissionsChannelService {
         this.__validateGetEmissionsDataInput(input);
         const fabricCaller: IFabricTxCaller = {
             userId: input.query.userId,
-            vaultToken: input.header.vault_token,
-            wsSessionId: input.header.session_id,
-            wsSidSig: input.header.signature,
+            vaultToken: input.header.vault_token as string,
+            webSocketKey: input.header.web_socket_key as IWebSocketKey,
         };
         const uuid = input.params.uuid;
         try {
@@ -295,9 +293,8 @@ export default class UtilityEmissionsChannelService {
         this.__validateGetAllEmissionsDataInput(input);
         const fabricCaller: IFabricTxCaller = {
             userId: input.query.userId,
-            vaultToken: input.header.vault_token,
-            wsSessionId: input.header.session_id,
-            wsSidSig: input.header.signature,
+            vaultToken: input.header.vault_token as string,
+            webSocketKey: input.header.web_socket_key as IWebSocketKey,
         };
         const utilityId = input.params.utilityId;
         const partyId = input.params.partyId;
@@ -327,9 +324,8 @@ export default class UtilityEmissionsChannelService {
         this.__validateGetAllEmissionsDataByDateRangeInput(input);
         const fabricCaller: IFabricTxCaller = {
             userId: input.query.userId,
-            vaultToken: input.header.vault_token,
-            wsSessionId: input.header.session_id,
-            wsSidSig: input.header.signature,
+            vaultToken: input.header.vault_token as string,
+            webSocketKey: input.header.web_socket_key as IWebSocketKey,
         };
         const fromDate = input.params.fromDate;
         const thruDate = input.params.thruDate;

--- a/utility-emissions-channel/typescript_app/src/static/openapi.json
+++ b/utility-emissions-channel/typescript_app/src/static/openapi.json
@@ -38,10 +38,7 @@
             "$ref" : "#/components/parameters/vaultToken"
           },
           {
-            "$ref" : "#/components/parameters/sessionId"
-          },
-          {
-            "$ref" : "#/components/parameters/signature"
+            "$ref" : "#/components/parameters/webSocketKey"
           }
         ],
         "requestBody": {
@@ -90,10 +87,7 @@
             "$ref" : "#/components/parameters/vaultToken"
           },
           {
-            "$ref" : "#/components/parameters/sessionId"
-          },
-          {
-            "$ref" : "#/components/parameters/signature"
+            "$ref" : "#/components/parameters/webSocketKey"
           },
           {
             "name": "eth_address",
@@ -170,10 +164,7 @@
             "$ref" : "#/components/parameters/vaultToken"
           },
           {
-            "$ref" : "#/components/parameters/sessionId"
-          },
-          {
-            "$ref" : "#/components/parameters/signature"
+            "$ref" : "#/components/parameters/webSocketKey"
           }
         ],
         "responses": {
@@ -233,10 +224,7 @@
             "$ref" : "#/components/parameters/vaultToken"
           },
           {
-            "$ref" : "#/components/parameters/sessionId"
-          },
-          {
-            "$ref" : "#/components/parameters/signature"
+            "$ref" : "#/components/parameters/webSocketKey"
           }
         ],
         "responses": {
@@ -296,10 +284,7 @@
             "$ref" : "#/components/parameters/vaultToken"
           },
           {
-            "$ref" : "#/components/parameters/sessionId"
-          },
-          {
-            "$ref" : "#/components/parameters/signature"
+            "$ref" : "#/components/parameters/webSocketKey"
           }
         ],
         "responses": {
@@ -336,10 +321,7 @@
             "$ref" : "#/components/parameters/vaultToken"
           },
           {
-            "$ref" : "#/components/parameters/sessionId"
-          },
-          {
-            "$ref" : "#/components/parameters/signature"
+            "$ref" : "#/components/parameters/webSocketKey"
           }
         ],
         "requestBody" : {
@@ -381,10 +363,7 @@
             "$ref" : "#/components/parameters/vaultToken"
           },
           {
-            "$ref" : "#/components/parameters/sessionId"
-          },
-          {
-            "$ref" : "#/components/parameters/signature"
+            "$ref" : "#/components/parameters/webSocketKey"
           }
         ],
         "requestBody" : {
@@ -660,24 +639,26 @@
           "example" : "[hex address]"
         }
       },
-      "sessionId" : {
-        "name": "session_id",
+      "webSocketKey" : {
+        "name": "web_socket_key",
         "description": "session id of web-socket ticket that can only be use by the app to communicate with the cilent's external key file",
         "in": "header",
         "required": false,
-        "schema" : {
-          "type": "string",
-          "example" : ""
-        }
-      },
-      "signature" : {
-        "name": "signature",
-        "description": "signature of session id required to access client keys over the ws-identity server",
-        "in": "header",
-        "required": false,
-        "schema" : {
-          "type": "string",
-          "example" : ""
+        "type": "object",
+        "example": "{sessionId:[string],signature:[string]}",
+        "schema":{
+          "properties": {
+            "sessionId": {
+              "type": "string",
+              "example" : ""
+            },
+            "signature": {
+             "description": "signature of session id required to access client keys over the ws-identity server",
+              "type": "string",
+              "example" : ""
+            }
+          },
+          "required": [ "sessionId","signature" ]
         }
       }
     }

--- a/utility-emissions-channel/typescript_app/tests/setup-ws.ts
+++ b/utility-emissions-channel/typescript_app/tests/setup-ws.ts
@@ -1,0 +1,29 @@
+import { WsWallet } from 'ws-wallet';
+import { IWebSocketKey } from '../src/blockchain-gateway/I-gateway';
+import { WsIdentityClient } from 'ws-identity-client';
+
+async function setupWebSocket(keyName: string): Promise<IWebSocketKey> {
+    const wsWalletAdmin = new WsWallet({
+        keyName,
+    });
+    const wsIdClient = new WsIdentityClient({
+        apiVersion: 'v1',
+        endpoint: process.env.WS_IDENTITY_ENDPOINT,
+        rpDefaults: {
+            strictSSL: false,
+        },
+    });
+    const { sessionId, url } = JSON.parse(
+        await wsIdClient.write(
+            'session/new',
+            {
+                pubKeyHex: wsWalletAdmin.getPubKeyHex(),
+                keyName: wsWalletAdmin.keyName,
+            },
+            {},
+        ),
+    );
+    return await wsWalletAdmin.open(sessionId, url);
+}
+
+export { setupWebSocket };


### PR DESCRIPTION
Replicate existing tests for VaultX509
Add gateway interface IWebSocketKey for webSocketKey object with sessionId and signature.
Extend service/input header to include Record with object values (not just strings).

Signed-off-by: brioux <Bertrand.rioux@gmail.com>