### PR TITLE
update documentation for ws-socket and vault security

### DIFF
--- a/secure-identities/README.md
+++ b/secure-identities/README.md
@@ -61,5 +61,17 @@ The video from [2021-10-25 Peer Programming Call](https://wiki.hyperledger.org/d
 ## Using the Vault Transit Server
 
 The Vault Transit server is a centralized secure server to store secret keys for a number of users.  The admin can set up different security profiles and then create users.  All users can generate tokens and Transit public keys.  Then the user can access Fabric by providing its token, and the Fabric application will check Vault's Transit key against the user's provided token to validate it.
+For example, from 1:14:00 in the video from the [2021-10-25 Peer Programming Session](https://wiki.hyperledger.org/display/CASIG/2021-10-25+Peer+Programming+Call), we see the following sequence:
 
-See [vault-identity/README.md] for more details on how to use the Vault Transit engine with Fabric.
+- Sign into the Vault REST API using the admin token (configured by default)
+- Create a new user
+- Using the username and password of the new user, create a Vault token
+- Create a Transit key for the admin
+- Logout as the admin
+- Login using the Vault token of the new user
+- Create a Transit key for the new user
+- From the Fabric REST API, use the register the new user using the Vault admin token.  Write down the enrollment id and enrollment secret
+- Now use the Vault new user's token to enroll that user, using the enrollment id and enrollment secret
+- Once the user is enrolled, you can perform operations using that user's Vault token
+
+See [Vault Identity README](vault-identity/README.md) for more details on how to use the Vault Transit engine with Fabric.

--- a/secure-identities/README.md
+++ b/secure-identities/README.md
@@ -14,58 +14,48 @@ Key files may also be stored separate from the identity credentials outside the 
 1. Private keys and certificates are stored in a cloud-based storage service (e.g., Hashicorp Vault) operated by an organization.
 2. Private keys are stored on the user's external device disconnected from the internet unless otherwise requested by the user.
 
-In the 1st approach an admin policy governs access to client key files on the central server. Key owners can issue and authenticate API tokens to applications (e.g., utility-emissions) so it can use the user's identity credentials.
+In the first approach, the organization manages its users and controls access to client keys on the secure server. Key owners can issue and authenticate API tokens for Fabric applications (e.g., utility-emissions) to use as the user's identity credentials.  A Vault-X.509 identity credential type is supported in the Fabric application.  The private keys always reside in the Vault server.  While the user can issue tokens from the private key based on the key policy, they do not have physical ownership of the private key.
 
-A Vault-X.509 identity credential type is provided by the utility-emissions-channel. When a Vault-X.509 Identity connection is closed, private keys still reside in the Vault server. The user controls the private key (based on the key policy) but does not have physical ownership.
+The major advantage of this approach is that clients are not responsible for communicating with the Fabric network. A single application is used to manage identities of multiple users.  This application could have enhanced security features and policies.  The major disadvantage of this approach is that all private keys are stored in a centralized location.  However secure, it is still a money pot for hackers to attempt to exploit/corrupt.
 
-- Major advantage of the 1st approach: clients are not responsible for communicating with fabric network. A single application is used to manage identities of multiple users.
-- Major disadvantage of the 1st approach: all private keys are stored in single database which leads to money pot for hackers to exploit/corrupt
+The second option allows key files to be physically held by the user, not a third-party app, who then has full control over its use as well.  This is a true decentralized approach, and the major advantage is that each client's private key is never exposed or stored on the organization's application.  The major disadvantage is that clients are responsible for managing their own private keys, as well as communicating with the Fabric network.  
 
+Choosing one over the other depends on whether the organization needs align with centralized identity services versus self-management and physical ownership of key files by its users.  A central secured server could be hardened with the best technology and security practices.  Individuals holding their own keys, on the other hand, do not present hackers with a single store containing many access keys. Some considerations for choosing one versus the other include:
 
-The 2nd option differs in those key files are controlled and physically owned by the user, not a third-party app. 
+- Do users demand full ownership of keys?
 
-- Major advantage of the 2nd approach: client's private key is never exposed or stored on the organization's application.
-- Major disadvantage in 2nd approach: clients are responsible for communicating with the fabric network and managing their own private keys.
-
-Choosing one over the other depends on whether the organization needs align with centralized identity services versus self-management and physical ownership of key files by its users.
-
-While the 1st option may be suitable for many cases, the 2nd option ensures decentralized ownership better suited to certain conditions:
-
-- Users demand full ownership of key files
-
-- Strict key access constraints
+- Are there strict key access constraints, such as
 
     * Security protocols set by a company or government require actual keys (not just the passwords that encrypt them) to be owned by the identity holder.
     * Physical ownership may be required by law.
+    * Certain security standards must be upheld for all keys
 
+- Key file physically locked within an external device, such as IoT or embedded devices.  Physical IoT devices may be enrolled with a network using private keys contained within a Hardware Security Module (HSM) that cannot be extracted and stored by a third party.  In this case, a WS-X.509 identity credential uses a secure web-socket based proxy to connection to the device.  Other proxy connections/credential types could be used. E.g., gRPC-X.509*
 
-- Key file physically locked within an external device.
-    
-    Physical IoT devices may be enrolled with a network with private keys contained within a Hardware Security Module (HSM) that cannot be extracted and stored by a third party. A WS-X.509 identity credential uses a secure web-socket based proxy to connection to the device.
-
-*Note: other proxy connections/credential types could be used. E.g., gRPC-X.509*
 
 ## Connecting external privates keys over web-socket
 
-In the [utility-emissions-channel](../utility-emissions-channel) a secure web-socket server connects the fabric application and a user’s external key file.
-A [WS-X.509 credential type for signing fabric transactions] (https://github.com/hyperledger/cactus/pull/1333) has been setup within the cactus connector for Fabric. 
+In the context of the emissions application, the web-socket client security framework supports a wallet installed on a device used by an auditor to sign verified emissions data, like a notary stamp to verify documents.  It could also be installed on a physical device, such as a CO2 sensor or other measurement tool, that relays information about emissions directly to the Fabric network.  Such a device could be a power plant, a transpiration vehicle, or a mobile remote sensor such as an airplane or satellite.  The connection between Fabric and the wallet is made via a [WS-X.509 credential type for signing fabric transactions] (https://github.com/hyperledger/cactus/pull/1333), which has been setup within the cactus connector for Fabric. 
 
-Two packages are required for this connection:
+This security framework requires two packages:
 
-* [ws-identity](./ws-identity/README.MD): server to setup and authenticate the web-socket connections
+* [ws-wallet](./ws-wallet/README.md) is a wallet which generates the user's offline private key and opens connection to the server
 
-* [ws-wallet](./ws-wallet/README.md): generate the user's offline private key and open connection to the Fabric peer
-
-The ws-identity server can either be hosted within the Fabric application or as a standalone endpoint linking a Fabric peer and ws-wallet instance.
+* [ws-identity](./ws-identity/README.MD) is a server to setup and authenticate the web-socket connections coming from wallets.  It can either be bundled within the Fabric application or set up as a standalone endpoint linking a Fabric peer and ws-wallet instance.
 
 The server does not store and never sees the user’s private key. It delivers request to sign various payloads, such as:
+
 - a Certificate Signing Request (CSR) used to construct the WS-X.509 identity file when enrolling with the Fabric application. 
-- a query or commit transactions to the Fabric network.
+- a transaction to the Fabric network to record or query data.
 
-[ws-identity-client](./ws-identity-client/README.md) is used to setup the backend connection between ws-identity or ws-wallet and the fabric network.
+A third package, [ws-identity-client](./ws-identity-client/README.md), is used to setup the backend connection between ws-identity or ws-wallet and the fabric network.
 
-### Use cases for external private keys
+### Example of a Web Socket Connection
 
-In the utility-emissions-channel the ws-wallet is used on a device owned by an auditor. It verifies emissions data used by the [net-emissions-token-network](../net-emissions-token-network), acting like a notary stamp to verify digital documents.
+The video from [2021-10-25 Peer Programming Call](https://wiki.hyperledger.org/display/CASIG/2021-10-25+Peer+Programming+Call) from 34:00 to 1:00:00 shows how to use the ws-wallet with Fabric.  The ws-identity server is bundled within the REST API of the utility emissions channel.  The process is:
 
-The ws-wallet could also be used by a physical device, such as a CO2 sensor or other measurement tool that relays information about emissions to the Fabric network. Such a device could be a power plant, a transpiration vehicle, or a mobile remote sensor such as an airplane or satellite. 
+    # Use `ws-wallet new-key` to create a key for a user.  It will store a private key and return the public key.
+    # Request a session through the REST API ending in `/identity/webSocket/` using your public key and user name.  The server will open up a session for your wallet to connect and return a sessionId and a connection URL.
+    # Now connect to the server using `ws-wallet connect <url> <sessionId>`  If the public key of your user agrees with the public key used to open the connection, then the server will return a signature and session key.  You can then use the signature and session key to perform additional operations on the REST API server, such as registering and enrolling users and operations on Fabric.
+
+## Using the Vault Transit Server

--- a/secure-identities/README.md
+++ b/secure-identities/README.md
@@ -54,9 +54,9 @@ A third package, [ws-identity-client](./ws-identity-client/README.md), is used t
 
 The video from [2021-10-25 Peer Programming Call](https://wiki.hyperledger.org/display/CASIG/2021-10-25+Peer+Programming+Call) from 34:00 to 1:00:00 shows how to use the ws-wallet with Fabric.  The ws-identity server is bundled within the REST API of the utility emissions channel.  The process is:
 
-    # Use `ws-wallet new-key` to create a key for a user.  It will store a private key and return the public key.
-    # Request a session through the REST API ending in `/identity/webSocket/` using your public key and user name.  The server will open up a session for your wallet to connect and return a sessionId and a connection URL.
-    # Now connect to the server using `ws-wallet connect <url> <sessionId>`  If the public key of your user agrees with the public key used to open the connection, then the server will return a signature and session key.  You can then use the signature and session key to perform additional operations on the REST API server, such as registering and enrolling users and operations on Fabric.
+- Use `ws-wallet new-key` to create a key for a user.  It will store a private key and return the public key.
+- Request a session through the REST API ending in `/identity/webSocket/` using your public key and user name.  The server will open up a session for your wallet to connect and return a sessionId and a connection URL.
+- Now connect to the server using `ws-wallet connect <url> <sessionId>`  If the public key of your user agrees with the public key used to open the connection, then the server will return a signature and session key.  You can then use the signature and session key to perform additional operations on the REST API server, such as registering and enrolling users and operations on Fabric.
 
 ## Using the Vault Transit Server
 

--- a/secure-identities/README.md
+++ b/secure-identities/README.md
@@ -59,3 +59,7 @@ The video from [2021-10-25 Peer Programming Call](https://wiki.hyperledger.org/d
     # Now connect to the server using `ws-wallet connect <url> <sessionId>`  If the public key of your user agrees with the public key used to open the connection, then the server will return a signature and session key.  You can then use the signature and session key to perform additional operations on the REST API server, such as registering and enrolling users and operations on Fabric.
 
 ## Using the Vault Transit Server
+
+The Vault Transit server is a centralized secure server to store secret keys for a number of users.  The admin can set up different security profiles and then create users.  All users can generate tokens and Transit public keys.  Then the user can access Fabric by providing its token, and the Fabric application will check Vault's Transit key against the user's provided token to validate it.
+
+See [vault-identity/README.md] for more details on how to use the Vault Transit engine with Fabric.

--- a/secure-identities/README.md
+++ b/secure-identities/README.md
@@ -61,6 +61,7 @@ The video from [2021-10-25 Peer Programming Call](https://wiki.hyperledger.org/d
 ## Using the Vault Transit Server
 
 The Vault Transit server is a centralized secure server to store secret keys for a number of users.  The admin can set up different security profiles and then create users.  All users can generate tokens and Transit public keys.  Then the user can access Fabric by providing its token, and the Fabric application will check Vault's Transit key against the user's provided token to validate it.
+
 For example, from 1:14:00 in the video from the [2021-10-25 Peer Programming Session](https://wiki.hyperledger.org/display/CASIG/2021-10-25+Peer+Programming+Call), we see the following sequence:
 
 - Sign into the Vault REST API using the admin token (configured by default)

--- a/secure-identities/vault-identity/README.md
+++ b/secure-identities/vault-identity/README.md
@@ -23,24 +23,45 @@ Steps required before running the server.
 
 A quick setup for development purpose:
 
-- Start vault server : `npm run vault`
+- Install: `nom install`
+- Start vault server - This is usually already started by `startApi.sh` in `utility-emissions-channel/docker-compose-setup/scripts/`ss, but if you don't see a vault docker container running, then : `npm run vault`   
 - Setup : `npm run test:setup`
 
-## Server
+## Using Vault
 
-Start Server
+Vault is accessed through a REST API for Vault.  The process is to use Vault to generate a token and a Transit engine public key for a user, and then use that token in the Fabric application.  The Fabric application's typescript REST API will check Vault for the Transit engine public key to match against the token.  If successful, it will allow the user to access operations in Fabric.
+
+For example, from 1:14:00 in the video from the [2021-10-25 Peer Programming Session](https://wiki.hyperledger.org/display/CASIG/2021-10-25+Peer+Programming+Call), we see the following sequence:
+
+- Sign into the Vault REST API using the admin token (configured by default)
+- Create a new user
+- Using the username and password of the new user, create a Vault token
+- Create a Transit key for the admin
+- Logout as the admin
+- Login using the Vault token of the new user
+- Create a Transit key for the new user
+- From the Fabric REST API, use the register the new user using the Vault admin token.  Write down the enrollment id and enrollment secret
+- Now use the Vault new user's token to enroll that user, using the enrollment id and enrollment secret
+- Once the user is enrolled, you can perform operations using that user's Vault token
+
+## Using the Vault API 
+
+### Start Server
 
 - `npm run build`
 - `npm run start`
 
+### Accessing the Vault REST API
 
-Swagger UI : <http://localhost:9090/api-docs/>
+Go to <http://localhost:9090/api-docs/>
 
-## Working With Endpoints
+Click on the "Authorize" button
 
-1. Create a Manager Identity : use `POST api/v1/identity`
+Set the admin user's authorization token, which by default is set by `npm run test:setup` to `tokenId`, to get started the first time.  Then later, when you have a token for another user, you can use it to authorize Vault.
 
-Set Authorizations token as : `tokenId`
+### API Endpoints
+
+1. Create a Manager Identity: use `POST api/v1/identity`
 
 Input :
 
@@ -51,7 +72,7 @@ Input :
 }
 ```
 
-Output :
+Sample output :
 
 ```json
 {
@@ -60,7 +81,7 @@ Output :
 }
 ```
 
-2. Generate Token From user/pass : use `POST api/v1/token`
+2. Generate Token from the user/password above: use `POST api/v1/token`
 
 Input :
 
@@ -113,6 +134,8 @@ Input :
 - kty : key type, two options
   - ecdsa-p256
   - ecdsa-p384
+
+After you create a Transit key, it will be available for use.  You don't have to write down the key yourself to pass around to Fabric later.
 
 6. Get Transit Key Details : use `GET api/v1/key`
 

--- a/secure-identities/vault-identity/README.md
+++ b/secure-identities/vault-identity/README.md
@@ -31,19 +31,6 @@ A quick setup for development purpose:
 
 Vault is accessed through a REST API for Vault.  The process is to use Vault to generate a token and a Transit engine public key for a user, and then use that token in the Fabric application.  The Fabric application's typescript REST API will check Vault for the Transit engine public key to match against the token.  If successful, it will allow the user to access operations in Fabric.
 
-For example, from 1:14:00 in the video from the [2021-10-25 Peer Programming Session](https://wiki.hyperledger.org/display/CASIG/2021-10-25+Peer+Programming+Call), we see the following sequence:
-
-- Sign into the Vault REST API using the admin token (configured by default)
-- Create a new user
-- Using the username and password of the new user, create a Vault token
-- Create a Transit key for the admin
-- Logout as the admin
-- Login using the Vault token of the new user
-- Create a Transit key for the new user
-- From the Fabric REST API, use the register the new user using the Vault admin token.  Write down the enrollment id and enrollment secret
-- Now use the Vault new user's token to enroll that user, using the enrollment id and enrollment secret
-- Once the user is enrolled, you can perform operations using that user's Vault token
-
 ## Using the Vault API 
 
 ### Start Server

--- a/secure-identities/ws-identity-client/README.md
+++ b/secure-identities/ws-identity-client/README.md
@@ -1,10 +1,10 @@
 # Client for web-socket identity servers
 
-This is a node.js client to connect with the web-socket identity server [ws-identity](https://github.com/brioux/ws-identity).
+This is a node.js client to connect with the web-socket identity server [ws-identity](../ws-identity/README.md).
 
 
 ## Requesting new session Id 
-  - Submit pubKeyHex to socket server and receice ws-identity session ticket
+  - Submit pubKeyHex to socket server and receive ws-identity session ticket
 ```typescript
   const wsSessionBackend = new WsIdentityClient({
     endpoint: [ws-server-address],

--- a/secure-identities/ws-identity/README.MD
+++ b/secure-identities/ws-identity/README.MD
@@ -1,13 +1,13 @@
 # Web Socket Identity Server
 
-An express.js app to access cryptophic signing capabilites over web-socket.
+An express.js app to access cryptographic signing capabilities over web-socket.
 
 ## WS-X.509 identity provider
-The ws-identity server supports X.509 certificates issued by a Certificate Authority (CA) where correspoinding private keys are stored offline in an external wallet. The server connects identities with a distributed network (e.g., hyperledger fabric). This could include:
+The ws-identity server supports X.509 certificates issued by a Certificate Authority (CA) where corresponding private keys are stored offline in an external wallet. The server connects identities with a distributed network (e.g., Hyperledger Fabric). This could include:
 * an IoT device
 * an auditor
 
- [ws-identity-client](https://github.com/brioux/ws-identity-client) setups the backend between ws-identity server and fabric network. A WS-X.509 identity provider is setup within the [cactus-plugin-ledger-connector-fabric](https://github.com/hyperledger/cactus/pull/1333).
+[ws-identity-client](../ws-identity-client/README.md) setups the backend between ws-identity server and Fabric network. A WS-X.509 identity provider is setup within the [cactus-plugin-ledger-connector-fabric](https://github.com/hyperledger/cactus/pull/1333).
 
 ws-identity server configuration:
 ```typescipt
@@ -29,7 +29,7 @@ export interface WebSocketKey {
 } 
 ```
 ## WS Crypto Wallet
-The prototype [ws-wallet](https://github.com/brioux/ws-wallet) setups and stores private keys on clients external device,and creates the client connection with the ws-identity server to enrol with a fabric CA and submit transactions to the blockchain.
+The prototype [ws-wallet](../ws-wallet/README.md) setups and stores private keys on clients external device and creates the client connection with the ws-identity server to interact with the Fabric network.
 
 ## build
 Install dependencies

--- a/secure-identities/ws-wallet/README.md
+++ b/secure-identities/ws-wallet/README.md
@@ -36,7 +36,7 @@ ws-wallet get-pkh [keyname]
 ws-wallet connect [url] [key-name] ([strict-ssl])
 ```
 requires:
-* [url] of the ws-identity host (e.g., 'http://localhost:8700')
+* [url] of the ws-identity host (e.g., 'ws://localhost:8700')
 * [key-name] of local keyfile with pub-key-hex addresss used to request new session ID
 * [strict-ssl] can be set to false when testing ssl/tls enabled ws-identity server
 


### PR DESCRIPTION
@brioux @Zzocker Can you please review these changes to the documentation based on our call on Monday?

I'm still not too clear where the ws-identity and ws-identity-client are vs each other. Does ws-wallet talk to ws-identity, which then talks through ws-identity-client to Fabric?

A client application that uses web socket identity then somehow incorporate ws-wallet in its UI?