### PR TITLE
feat(CI): Add linting and tests for datalock chaincode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           go-version: "1.16"
       - name: Run chaincode tests
-        run: go test internal/*.go -count=1
+        run: go test -v internal/*.go -count=1
 
   test-typescript-app:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Run lint script
         run: npm run lint
 
-  lint-typescript-chaincode:
+  lint-utility-emissions-chaincode:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -57,6 +57,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
+        with:
+          go-version: "1.16"
       - name: Run chaincode tests
         run: go test internal/*.go -count=1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Run lint script
         run: npm run lint
 
-  lint-chaincode:
+  lint-typescript-chaincode:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -40,7 +40,27 @@ jobs:
       - name: Run lint script
         run: npm run lint
 
-  test:
+  lint-datalock-chaincode:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run lint script
+        uses: golangci/golangci-lint-action@v2
+        with:
+          working-directory: ./utility-emissions-channel/chaincode/datalock
+
+  test-datalock-chaincode:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./utility-emissions-channel/chaincode/datalock
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+      - name: Run chaincode tests
+        run: go test internal/*.go -count=1
+
+  test-typescript-app:
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
This PR adds linting and chaincode tests to the existing CI pipeline for the [datalock chaincode](https://github.com/hyperledger-labs/blockchain-carbon-accounting/tree/main/utility-emissions-channel/chaincode/datalock). It uses the same scripts as specified in the Makefile. I have used [this action](https://github.com/marketplace/actions/run-golangci-lint) to setup the golangcli-lint tool.

Closes #306.