### PR TITLE
feat (test): Add MD5 checksum test for emission records

### DIFF
--- a/utility-emissions-channel/typescript_app/src/datasource/awsS3.ts
+++ b/utility-emissions-channel/typescript_app/src/datasource/awsS3.ts
@@ -1,4 +1,5 @@
 import { S3, Endpoint, AWSError } from 'aws-sdk';
+import { DeleteObjectOutput } from 'aws-sdk/clients/s3';
 export default class AWSS3 {
     private readonly s3: S3;
     private readonly bucketName: string;
@@ -58,5 +59,23 @@ export default class AWSS3 {
                 },
             );
         });
+    }
+    delete(filename: string): Promise<DeleteObjectOutput> {
+        return new Promise(
+            (resolve: (value: DeleteObjectOutput) => void, reject: (err: AWSError) => void) => {
+                this.s3.deleteObject(
+                    {
+                        Bucket: this.bucketName,
+                        Key: filename,
+                    },
+                    (err: AWSError, data) => {
+                        if (err) {
+                            return reject(err);
+                        }
+                        resolve(data);
+                    },
+                );
+            },
+        );
     }
 }

--- a/utility-emissions-channel/typescript_app/tests/blockchain-gateway/utilityEmissionsChannel.test.ts
+++ b/utility-emissions-channel/typescript_app/tests/blockchain-gateway/utilityEmissionsChannel.test.ts
@@ -159,7 +159,7 @@ describe('UtilityemissionchannelGateway', () => {
                     thruDate: '2021-05-07T10:10:09Z',
                     energyUseAmount: 100,
                     energyUseUom: 'kWh',
-                    url: '',
+                    url: 'localost:///tmp/filename',
                     md5: '',
                 });
                 const documentUrl = data.url;


### PR DESCRIPTION
Every time a new emission is recorded, its MD5 digest is computed and stored on the ledger. Then, when the emission is retrieved again, the MD5 digest is re-computed and is checked against the value stored in the ledger. This PR exercises this functionality as a test, by deleting the emission document and then adding a dummy document in its place. This should cause the MD5 digest to be changed, and hence the test should fail.

Closes #188.