### PR TITLE
Add REST request endpoint for ws-wallet connection to ws-identity server

### DIFF
--- a/secure-identities/ws-identity/src/client.ts
+++ b/secure-identities/ws-identity/src/client.ts
@@ -23,7 +23,6 @@ export class WebSocketClient {
   public readonly pubKeyEcdsa: KJUR.crypto.ECDSA; // KJUR.crypto.ECDSA for csr requests;
   public readonly ip: string;
   public readonly pubKeyHex: string;
-  // public readonly sessionId: string;
   public readonly keyName: string;
   private readonly log: Logger;
   private readonly webSocket: WebSocket;
@@ -37,7 +36,6 @@ export class WebSocketClient {
     this.webSocket = opts.webSocket
     this.ip = opts.clientIp
     this.pubKeyEcdsa = opts.pubKeyEcdsa
-    // this.sessionId = opts.sessionId
     this.pubKeyHex = this.pubKeyEcdsa.pubKeyHex
     this.keyName = opts.keyName || `${this.pubKeyHex.substring(0, 12)}...`
   }

--- a/secure-identities/ws-identity/src/index.ts
+++ b/secure-identities/ws-identity/src/index.ts
@@ -1,8 +1,9 @@
 export {
-  WsIdentityServer,
-  WsIdentityServerOpts
+    IWebSocketKey,
+    WsIdentityServer,
+    WsIdentityServerOpts
 } from './server'
 export {
-  WsIdentityRouter,
-  WsIdentityRouterOpts
+    WsIdentityRouter,
+    WsIdentityRouterOpts
 } from './router'

--- a/secure-identities/ws-identity/src/server.ts
+++ b/secure-identities/ws-identity/src/server.ts
@@ -16,6 +16,11 @@ import {
   WSClientOpts
 } from './client'
 
+export interface IWebSocketKey {
+  sessionId: string;
+  signature: string;
+}
+
 export interface WsIdentityServerOpts {
   // existing server where all incoming web socket connections are directed.
   server: Server | ServerS;
@@ -143,8 +148,7 @@ export class WsIdentityServer {
     })
     webSocketServer.on('connection', function connection (
       webSocket: WebSocket,
-      sessionId: string
-      // signature: string,
+      sessionId: string,
     ) {
       const client = clients[sessionId] as null | WebSocketClient
       log.info(`session ${sessionId} in progress for ${client.keyName}`)
@@ -223,7 +227,7 @@ export class WsIdentityServer {
   }
 
   /* Public function previously used for testing
-      Not to be used in production!!!
+      Not to be used in production
   */
   public async waitForSocketClient (
     sessionId: string,

--- a/secure-identities/ws-wallet/bin/index.ts
+++ b/secure-identities/ws-wallet/bin/index.ts
@@ -16,14 +16,28 @@ if (yargs.argv.k) {
 } else if (yargs.argv._[0] === 'new-key') {
   utils.generateKey({ keyName: yargs.argv._[1], curve: yargs.argv._[2] });
 } else if (yargs.argv._[0] === 'get-pkh') {
-  console.log(utils.getPubKeyHex(yargs.argv._[1]));
+  console.log(utils.getPubKeyHex({keyName: yargs.argv._[1]}));
+} else if (yargs.argv._[0] === 'open'){
+  (async () => {
+    const resp = await utils.newSession(
+      yargs.argv._[1],
+      yargs.argv._[2],
+      eval(yargs.argv._[3])
+    )
+    console.log(JSON.stringify(resp))
+  })()
 } else if (yargs.argv._[0] === 'connect') {
-  utils.getClient(
-    yargs.argv._[1], 
-    yargs.argv._[2], 
-    {keyName: yargs.argv._[3]},
-    eval(yargs.argv._[4])
-  );
+  (async () => {
+    const resp = await utils.openSession(
+      yargs.argv._[1], 
+      yargs.argv._[2], 
+      yargs.argv._[3],
+      eval(yargs.argv._[4])
+    );
+    console.log(resp)
+  })()
 } else {
   utils.showHelp();
 }
+
+export {};

--- a/secure-identities/ws-wallet/bin/utils.ts
+++ b/secure-identities/ws-wallet/bin/utils.ts
@@ -1,13 +1,16 @@
 import { WsWallet } from '../src/wallet';
 import { keyGen, getPubKeyHex, listKeys, IClientNewKey } from '../src/key';
-
+import axios from 'axios';
+import { IWebSocketKey } from '../src/wallet'
 let usage = '\nUsage: ws-wallet\n';
 usage +=
   '\tnew-key <keyname> [<curve>]\t' +
   "\tGenerate new key with curve: 'p256' | 'p384'\n";
-usage += '\tget-pkh <keyname>\t' + '\t\tGet publick key hex of keyname\n';
+usage += '\tget-pkh <keyname>\t' + '\t\tGet public key hex of keyname\n';
+usage += '\topen <keyname> <endpoint> [<sslStrict>] \t' + 'Open ws-identity session from host with keyname\n'; 
+
 usage += '\tconnect <host> <sessionId> <keyname> [<sslStrict>] \t' + 'Connect to ws-identity server\n'; 
-usage += '...      \t \t \t use sslStric for testing with unverified ssl/tls certificates\n';
+usage += '...      \t \t \t use sslStrict for testing with unverified ssl/tls certificates\n';
 
 function showHelp() {
   console.log(usage);
@@ -23,10 +26,56 @@ function showHelp() {
   );
 }
 
-async function getClient(endpoint:string,sessionId:string,args: IClientNewKey,strictSSL?:boolean) {
-  const wsClient = new WsWallet({ endpoint, keyName: args.keyName, strictSSL});
-  const key = await wsClient.open(sessionId);
-  console.log(key);
+
+  /**
+   * @description request new session with ws-identity server (identity proxy 
+   * to communicate with Fabric application) and webSocketKey for the session
+   * @param userId : name of key file stored by ws-wallet locally 
+   * also sets the userID fof storing the WS-X.509 certificate enrolled with Fabric;
+   * @param endpoint: url to access the API provide by Fabric applicaiton 
+   * to request a new ws-identity session ticket
+   * @return IWebSocketKey: the key needed to access the open web-socket conneciton
+   * @note the session ticket must be requested by the Fabric app that will use it
+   * because the ws-identity server matches the IP used to request the ticket with
+   * the IP connecting to it later (so that other apps can't use the same session)
+   * To open a webSocketKey the ws-wallet makes a REST request to trigger the 
+   * Fabric app to request a session ticket, signs the sessionId response
+   * and uses it to open a websocket client with the ws-identity server
+   * at the url provided in the REST response 
+   */
+async function newSession(
+  userId:string,
+  endpoint:string,
+  strictSSL?:boolean):Promise<IWebSocketKey>{ 
+  let wsKey
+  await axios.post(endpoint,{userId},
+    {
+      headers: {
+        'accept': 'application/json',
+        'pub_key_hex': getPubKeyHex({keyName:userId}),
+      },
+    },
+  ).then(async function(response) {
+    const {url,sessionId} = response.data;
+    wsKey = await openSession(url,sessionId,userId);
+  });
+  return wsKey; 
+}
+  /**
+   * @description open ws-idenity session client by signing the sessionId
+   * @param endpoint: url of the web-socket server
+   * @param sessionId: id of the session ticket to be signed
+   * @param keyName: name of the key file used to sign the sesisonID
+   * @return IWebSocketKey
+   */
+async function openSession(
+  endpoint:string,
+  sessionId:string,
+  keyName: string,
+  strictSSL?:boolean):Promise<IWebSocketKey> {
+  const wsClient = new WsWallet({ endpoint, keyName, strictSSL});
+  const key:IWebSocketKey = await wsClient.open(sessionId);
+  return key
 }
 
 async function generateKey(args: IClientNewKey) {
@@ -37,7 +86,8 @@ async function generateKey(args: IClientNewKey) {
 export default {
   usage,
   showHelp,
-  getClient,
+  newSession,
+  openSession,
   generateKey,
   getPubKeyHex,
   listKeys,

--- a/secure-identities/ws-wallet/package.json
+++ b/secure-identities/ws-wallet/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@hyperledger/cactus-common": "0.9.0",
     "@types/yargs": "^17.0.2",
+    "axios": "^0.24.0",
     "elliptic": "^6.5.4",
     "jsrsasign": "^10.4.0",
     "winston": "^3.3.3",

--- a/secure-identities/ws-wallet/src/key.ts
+++ b/secure-identities/ws-wallet/src/key.ts
@@ -41,7 +41,7 @@ export function keyGen (args: IClientNewKey) {
     const info = []
     const keyPath = getKeyPath(args.keyName)
     if (fs.existsSync(keyPath)) {
-      return `${args.keyName} key already exists.`
+      return `${args.keyName} key already exists`
     }
     if (!args.curve) {
       info.push('No curve specified. Set to p256 as default')
@@ -63,14 +63,15 @@ export function keyGen (args: IClientNewKey) {
   }
 }
 
-export function getPubKeyHex (keyName) {
-  const keyPath = getKeyPath(keyName)
-  if (fs.existsSync(keyPath)) {
+export function getPubKeyHex (args: IClientNewKey) {
+  const keyPath = getKeyPath(args.keyName)
+  console.log(keyGen(args));
+  try {
     const keyData = JSON.parse(fs.readFileSync(keyPath, 'utf8'))
     const { pubKeyHex } = KEYUTIL.getKey(keyData.pubKey)
-    return `pubKeyHex: ${pubKeyHex}`
-  } else {
-    return 'No key file found'
+    return pubKeyHex
+  }catch(error) {
+    throw new Error(`Error retrieving pub-key-hex: ${error}`)
   }
 }
 export function listKeys () {

--- a/secure-identities/ws-wallet/src/wallet.ts
+++ b/secure-identities/ws-wallet/src/wallet.ts
@@ -38,7 +38,7 @@ export interface WsWalletReq {
   index: number;
 }
 
-interface WsOpenResp {
+export interface IWebSocketKey {
   signature:string;
   sessionId:string;
 }
@@ -93,17 +93,9 @@ export class WsWallet {
   }
 
   /**
-   * @description asynchronous request to get a new key and open new ws connection
-   * @param args @type IClientNewKey
-   */
-  public getKey (args: IClientNewKey) {
-    this.keyData = this.initKey(args)
-  }
-
-  /**
    * @description Closes existing and open new websocket connection for client
    */
-  public async open (sessionId: string, endpoint?: string): Promise<WsOpenResp> {
+  public async open (sessionId: string, endpoint?: string): Promise<IWebSocketKey> {
     const fnTag = `${this.className}#open`
     this.opts.endpoint = endpoint || this.opts.endpoint
     Checks.nonBlankString(this.opts.endpoint, `${fnTag}:this.opts.endpoint`)
@@ -127,7 +119,7 @@ export class WsWallet {
           'x-pub-key-pem': JSON.stringify(this.keyData.pubKey)
         }
       }
-      this.log.debug(`${fnTag} create web-socket client to ${this.opts.endpoint}`)
+      this.log.debug(`${fnTag} create web-socket client for ${this.opts.endpoint}`)
       this.ws = new WebSocket(this.opts.endpoint, wsOpts)
 
       const { opts, keyName, ws, log, keyData } = this
@@ -143,7 +135,7 @@ export class WsWallet {
       this.ws.onclose = function incoming () {
         log.info(`${fnTag} connection to ${opts.endpoint} closed for key ${keyName}`)
       }
-      return await new Promise<WsOpenResp>(function (resolve, reject) {
+      return await new Promise<IWebSocketKey>(function (resolve, reject) {
         ws.addEventListener(
           'open',
           function incoming () {
@@ -155,7 +147,7 @@ export class WsWallet {
             })
           },
           { once: true }
-        ) as WsOpenResp
+        ) as IWebSocketKey
         ws.onerror = function (error) {
           // TODO extract error message from failed connection
           ws.close()

--- a/utility-emissions-channel/typescript_app/src/static/openapi.json
+++ b/utility-emissions-channel/typescript_app/src/static/openapi.json
@@ -641,7 +641,7 @@
       },
       "webSocketKey" : {
         "name": "web_socket_key",
-        "description": "session id of web-socket ticket that can only be use by the app to communicate with the cilent's external key file",
+        "description": "web-socket key required by the app to communicate with the cilent's external key file",
         "in": "header",
         "required": false,
         "type": "object",


### PR DESCRIPTION
    ws-wallet open [keyname] [endpoint]
    open connection for keyname to ws-identity server
    provide a websock session endpoint of the fabric app that will use this connection
    i.e., the session can only be used by the IP address of the app that requests it