### PR TITLE
Add password encryption to PKCS#8 private key

### DIFF
--- a/secure-identities/ws-wallet/bin/index.ts
+++ b/secure-identities/ws-wallet/bin/index.ts
@@ -9,12 +9,22 @@ yargs.usage(utils.usage)
     type: 'boolean',
     demandOption: false,
   })
+  .option('p', {
+    alias: 'pass',
+    describe: 'password that encrypts PKCS#8 key file',
+    type: 'string',
+  })
+  .option('s', {
+    alias: 'sslStrict',
+    describe: 'set sslStrict to false for testing with unverified ssl/tls certificates',
+    type: 'boolean',
+  })
   .help(true).argv;
 
 if (yargs.argv.k) {
   console.log(utils.listKeys().join('\n'));
 } else if (yargs.argv._[0] === 'new-key') {
-  utils.generateKey({ keyName: yargs.argv._[1], curve: yargs.argv._[2] });
+  utils.generateKey({ keyName: yargs.argv._[1], password: yargs.argv.p, curve: yargs.argv._[2] });
 } else if (yargs.argv._[0] === 'get-pkh') {
   console.log(utils.getPubKeyHex({keyName: yargs.argv._[1]}));
 } else if (yargs.argv._[0] === 'open'){
@@ -22,7 +32,8 @@ if (yargs.argv.k) {
     const resp = await utils.newSession(
       yargs.argv._[1],
       yargs.argv._[2],
-      eval(yargs.argv._[3])
+      yargs.argv.p,
+      eval(yargs.argv.ssl)
     )
     console.log(JSON.stringify(resp))
   })()
@@ -32,7 +43,8 @@ if (yargs.argv.k) {
       yargs.argv._[1], 
       yargs.argv._[2], 
       yargs.argv._[3],
-      eval(yargs.argv._[4])
+      yargs.argv.p,
+      eval(yargs.argv.ssl)
     );
     console.log(resp)
   })()

--- a/secure-identities/ws-wallet/src/wallet.ts
+++ b/secure-identities/ws-wallet/src/wallet.ts
@@ -1,7 +1,7 @@
 import WebSocket from 'ws'
 import fs from 'fs'
 import elliptic from 'elliptic'
-import { keyGen, getKeyPath, IClientNewKey, KeyData, ECCurveType } from './key'
+import { keyGen, getKeyPath, getPass, IClientNewKey, KeyData, ECCurveType } from './key'
 import { KEYUTIL } from 'jsrsasign'
 import {
   Logger,
@@ -25,6 +25,7 @@ export interface WsWalletOpts {
   keyName?: string;
   curve?: ECCurveType;
   logLevel?: LogLevelDesc;
+  password?: string
   // set to false for testing https/wss
   strictSSL?: boolean;
 }
@@ -48,7 +49,6 @@ export class WsWallet {
   private readonly log: Logger;
   private readonly endpoint: string;
   private ecdsaCurves: IEcdsaCurves;
-  public keyName: string;
   private keyData: KeyData;
   private ws?: WebSocket;
 
@@ -59,8 +59,8 @@ export class WsWallet {
       label: 'WsWallet',
       level: opts.logLevel || 'TRACE'
     })
-    opts.keyName = opts.keyName || 'default'
-    this.keyData = this.initKey({ keyName: opts.keyName, curve: opts.curve })
+    this.opts.keyName = opts.keyName || 'default'
+    this.keyData = this.initKey(this.opts as IClientNewKey) 
   }
 
   /**
@@ -73,13 +73,14 @@ export class WsWallet {
     this.log.debug(
       `${fnTag} look for key with name '${args.keyName}' or generate new key`
     )
+    this.close();
     const info = []
     const keyPath = getKeyPath(args.keyName)
     if (!fs.existsSync(keyPath)) {
       info.push(keyGen(args))
     }
     info.push(`extracting key '${args.keyName}' from key store`)
-    this.keyName = args.keyName
+    this.opts.keyName = args.keyName
     const keyData = JSON.parse(fs.readFileSync(keyPath, 'utf8'))
     const curve = keyData.curve
     if (args.curve && curve !== args.curve) {
@@ -99,17 +100,20 @@ export class WsWallet {
     const fnTag = `${this.className}#open`
     this.opts.endpoint = endpoint || this.opts.endpoint
     Checks.nonBlankString(this.opts.endpoint, `${fnTag}:this.opts.endpoint`)
-    this.log.debug(`${fnTag} web-socket connection to ${this.opts.endpoint} for ${this.keyName}`)
+    this.log.debug(`${fnTag} web-socket connection to ${this.opts.endpoint} for ${this.opts.keyName}`)
     this.close()
     try {
-      // get session id and mount path for websocket connection
-      this.log.debug(`${fnTag} request session ID for ${this.getPubKeyHex().substring(0, 12)}...`)
+      this.log.debug(`${fnTag} retrieve password to unlock private key`)
+      this.opts.password = await unlockKey(this.keyData,this.opts.password,this.log)
 
-      const sessionSignature = sign(
+      this.log.debug(`${fnTag} sign session ID for ${this.getPubKeyHex().substring(0, 12)}...`)
+
+      const sessionSignature = (await this.sign(
         Buffer.from(sessionId, 'hex'),
         this.keyData,
-        this.log
-      ).toString('hex')
+        this.opts.password,
+        this.log,
+      )).toString('hex')
 
       const wsOpts = {
         rejectUnauthorized: this.opts.strictSSL !== false,
@@ -122,18 +126,18 @@ export class WsWallet {
       this.log.debug(`${fnTag} create web-socket client for ${this.opts.endpoint}`)
       this.ws = new WebSocket(this.opts.endpoint, wsOpts)
 
-      const { opts, keyName, ws, log, keyData } = this
+      const { opts, ws, sign, keyData, log } = this
       this.ws.onopen = function () {
-        log.info(`${fnTag} connection opened to ${opts.endpoint} for key ${keyName}`)
+        log.info(`${fnTag} connection opened to ${opts.endpoint} for key ${opts.keyName}`)
       }
-      this.ws.on('message', function incoming (digest:Buffer) { // message: WsWalletReq
-        const signature = sign(digest, keyData, log)
+      this.ws.on('message', async function incoming (digest:Buffer) { // message: WsWalletReq
+        const signature = await sign(digest,keyData,opts.password,log)
         // const resp:WsWalletRes = {signature,index: message.index}
         log.info(`${fnTag} send signature to ${ws.url}: ${signature.toString('base64')}`)
         ws.send(signature)
       })
       this.ws.onclose = function incoming () {
-        log.info(`${fnTag} connection to ${opts.endpoint} closed for key ${keyName}`)
+        log.info(`${fnTag} connection to ${opts.endpoint} closed for key ${opts.keyName}`)
       }
       return await new Promise<IWebSocketKey>(function (resolve, reject) {
         ws.addEventListener(
@@ -158,7 +162,7 @@ export class WsWallet {
       this.log.error(
         `${fnTag} failed to connect with ${this.opts.endpoint}: ${error}`
       )
-      throw new Error(error)
+      //throw new Error(error)
     }
   }
 
@@ -179,26 +183,48 @@ export class WsWallet {
     const { pubKeyHex } = KEYUTIL.getKey(this.keyData.pubKey)
     return pubKeyHex
   }
+
+  /**s
+  * @description generate
+  * @param prehashed digest as Buffer
+  * @returns signature as string
+  */
+  private async sign(digest: Buffer, keyData:KeyData, password: string, log:any): Promise<Buffer> { 
+    const fnTag = '#sign'
+    log?.debug(`${fnTag} digest-size = ${digest.length}`)
+    try {
+      const { prvKeyHex } = KEYUTIL.getKey(keyData.key, password)
+      const ecdsa = ecdsaCurves[keyData.curve]
+      const signKey = ecdsa.keyFromPrivate(prvKeyHex, 'hex')
+      const sig = ecdsa.sign(digest, signKey)
+      const signature = Buffer.from(sig.toDER())
+      return signature
+    } catch (error) {
+      console.log(error)
+      throw new Error(`${fnTag} failed to produce signature: ${error}`)
+    }
+  }
 }
 
-/**
- * @description generate
- * @param prehashed digest as Buffer
- * @returns signature as string
- */
-function sign (digest: Buffer, keyData: KeyData, log?: any): Buffer {
-  const fnTag = '#sign'
-  log?.debug(`${fnTag} digest-size = ${digest.length}`)
-  try {
-    const { prvKeyHex } = KEYUTIL.getKey(keyData.key)
-    const ecdsa = ecdsaCurves[keyData.curve]
-    const signKey = ecdsa.keyFromPrivate(prvKeyHex, 'hex')
-    const sig = ecdsa.sign(digest, signKey)
-    const signature = Buffer.from(sig.toDER())
-    return signature
-  } catch (error) {
-    log?.error(`${fnTag} failed to produce signature: ${error}`)
-  }
+function unlockKey(keyData:KeyData,password?,log?,attempt=1): Promise<string>{
+  return new Promise(function (resolve, reject) {
+    
+    if(attempt<4){
+      setTimeout(async function () {
+        password = await getPass(password);
+        try {
+          KEYUTIL.getKey(keyData.key, password)
+          resolve(password)
+        }catch(err){
+          attempt += 1
+          log.error(`Error unlocking key file: ${err}`)
+          unlockKey(keyData,null,log,attempt).then(resolve)
+        }
+      })
+    }else{
+      reject(new Error('Too many failed password attempts'))
+    }
+  })
 }
 
 /**


### PR DESCRIPTION
    - ws-wallet new-key requests user to input password to encrypt PKCS#8 private key
    - ws-wallet open will request password to decrypt private key for signing
    - getPass() fn handles terminal requests to input passwor 
    - unlockKey() fn checks if decryption password is valid. Process closed after 3 failed attempts
    - Password -p option can be provided with new-key and open commands

Signed-off-by: brioux <Bertrand.rioux@gmail.com>