### PR TITLE
feat (test): Test if emission factors for the correct year are used

### DIFF
--- a/utility-emissions-channel/typescript_app/tests/blockchain-gateway/datalock.test.ts
+++ b/utility-emissions-channel/typescript_app/tests/blockchain-gateway/datalock.test.ts
@@ -41,7 +41,7 @@ describe('DataLockGateway', () => {
                 fabricConnector: org.connector,
                 signer: signer,
             }).recordEmissions(adminCaller, {
-                utilityId: 'USA_EIA_252522444142552441242521',
+                utilityId: 'USA_EIA_11208',
                 partyId: uuid4(),
                 fromDate: '2020-05-07T10:10:09Z',
                 thruDate: '2021-05-07T10:10:09Z',

--- a/utility-emissions-channel/typescript_app/tests/e2e.test.ts
+++ b/utility-emissions-channel/typescript_app/tests/e2e.test.ts
@@ -26,7 +26,7 @@ const apiEndpoints = {
 
 const adminVaultToken = 'tokenId';
 const userId = 'admin';
-const mockUtilityID = 'USA_EIA_252522444142552441242521';
+const mockUtilityID = 'USA_EIA_11208';
 
 describe('E2E-vault', () => {
     tests('vault_token', adminVaultToken);
@@ -111,7 +111,7 @@ function tests(headerKey, headerValue) {
     });
     const partyId = uuid4();
     let uuid: string;
-    it('should record a emissions', (done) => {
+    it('should record an emission', (done) => {
         chai.request(v1Base)
             .post(apiEndpoints.recordEmissions)
             .set('content-type', 'application/x-www-form-urlencoded')

--- a/utility-emissions-channel/typescript_app/tests/setup.ts
+++ b/utility-emissions-channel/typescript_app/tests/setup.ts
@@ -4,6 +4,7 @@ import {
     FabricContractInvocationType,
     FabricSigningCredential,
 } from '@hyperledger/cactus-plugin-ledger-connector-fabric';
+// import { execSync } from 'child_process';
 import { config } from 'dotenv';
 import axios from 'axios';
 config();
@@ -11,7 +12,6 @@ config();
 const bcConfig = new BCGatewayConfig();
 
 // insert mock utility identifier and factors
-const mockUtilityID = 'USA_EIA_252522444142552441242521';
 async function mockEmissionsRecord() {
     const signer: FabricSigningCredential = {
         keychainId: 'inMemoryKeychain',
@@ -27,9 +27,12 @@ async function mockEmissionsRecord() {
         caId: org.caID,
         mspId: org.orgMSP,
     });
+
     const channelName = 'utilityemissionchannel';
     const ccName = 'utilityemissions';
     // import utility identifier
+    const mockUtilityID = 'USA_EIA_11208';
+
     const p1 = hlfConnector.transact({
         signingCredential: signer,
         channelName: channelName,
@@ -39,13 +42,13 @@ async function mockEmissionsRecord() {
         params: [
             mockUtilityID,
             '2019',
-            '252522444142552441242521',
-            'test-utility-name',
+            '11208',
+            'Los Angeles Department of Water & Power',
             'USA',
             '',
             JSON.stringify({
                 division_type: 'NERC_REGION',
-                division_id: 'MRO',
+                division_id: 'WECC',
             }),
         ],
     });
@@ -58,24 +61,48 @@ async function mockEmissionsRecord() {
         invocationType: FabricContractInvocationType.Send,
         methodName: 'importUtilityFactor',
         params: [
-            'mock-utility-factor',
-            '2019',
+            'USA_2018_NERC_REGION_WECC',
+            '2018',
             'USA',
             'NERC_REGION',
-            'MRO',
-            'SERC_Reliability_Corporation',
-            '46112136.165',
+            'WECC',
+            'Western_Electricity_Coordinating_Council',
+            '743291275',
             'MWH',
-            '47582155.875',
+            '288021204',
             'tons',
             'https://www.epa.gov/sites/production/files/2020-01/egrid2018_all_files.zip',
-            '41078452.268',
-            '5033683.71',
+            '443147683',
+            '300143593',
             '',
         ],
     });
 
-    await Promise.all([p1, p2]);
+    const p3 = hlfConnector.transact({
+        signingCredential: signer,
+        channelName: channelName,
+        contractName: ccName,
+        invocationType: FabricContractInvocationType.Send,
+        methodName: 'importUtilityFactor',
+        params: [
+            'USA_2019_NERC_REGION_WECC',
+            '2019',
+            'USA',
+            'NERC_REGION',
+            'WECC',
+            'Western_Electricity_Coordinating_Council',
+            '738835346',
+            'MWH',
+            '285747759',
+            'tons',
+            'https://www.epa.gov/sites/production/files/2021-02/egrid2019_data.xlsx',
+            '447805417',
+            '291029929',
+            '',
+        ],
+    });
+
+    await Promise.all([p1, p2, p3]);
 }
 
 async function setupVault() {


### PR DESCRIPTION
This PR modifies the test setup script to use the real utility data present in the eGRID 2018 and 2019 datasets (Los Angeles Department of Water and Power), to insert 2 data records.  Then, 2 emissions are recorded, one in the year 2018 and one in the year 2019. Then we assert the following conditions:
- The emissions amounts of both years must not be equal
- The emissions amounts of each year should match the value calculated as per the eGRID data of that year

The emissions data is fetched from the CouchDB database using the [HTTP /db/_find API](https://docs.couchdb.org/en/latest/api/database/find.html). Then, the emissions factors are calculated and checked against the values stored on the ledger.

Closes #302 and #316.