### PR TITLE
feat (test): Test if emission factors for the correct region are used

### DIFF
--- a/utility-emissions-channel/chaincode/typescript/src/lib/utilityEmissionsFactor.ts
+++ b/utility-emissions-channel/chaincode/typescript/src/lib/utilityEmissionsFactor.ts
@@ -128,7 +128,7 @@ export class UtilityEmissionsFactorState extends WorldState<UtilityEmissionsFact
         lookup: UtilityLookupItemInterface,
         thruDate: string,
     ): Promise<UtilityEmissionsFactor> {
-        const hasStateData = lookup.state_province.length > 0;
+        const hasStateData = lookup.state_province !== undefined;
         const isNercRegion = lookup.divisions.division_type.toLowerCase() === 'nerc_region';
         const isNonUSCountry =
             lookup.divisions.division_type.toLowerCase() === 'country' &&
@@ -163,6 +163,7 @@ export class UtilityEmissionsFactorState extends WorldState<UtilityEmissionsFact
             divisionType,
             year,
         );
+        console.log(utilityFactors);
         if (utilityFactors.length === 0) {
             throw new Error('No utility emissions factor found for given query');
         }

--- a/utility-emissions-channel/typescript_app/tests/setup.ts
+++ b/utility-emissions-channel/typescript_app/tests/setup.ts
@@ -53,8 +53,28 @@ async function mockEmissionsRecord() {
         ],
     });
 
-    // import mock utility factor
     const p2 = hlfConnector.transact({
+        signingCredential: signer,
+        channelName: channelName,
+        contractName: ccName,
+        invocationType: FabricContractInvocationType.Send,
+        methodName: 'importUtilityIdentifier',
+        params: [
+            'RWE_AG',
+            '2019',
+            '1',
+            'RWE AG',
+            'DE',
+            '',
+            JSON.stringify({
+                division_type: 'COUNTRY',
+                division_id: 'Germany',
+            }),
+        ],
+    });
+
+    // import mock utility factor
+    const p3 = hlfConnector.transact({
         signingCredential: signer,
         channelName: channelName,
         contractName: ccName,
@@ -78,7 +98,7 @@ async function mockEmissionsRecord() {
         ],
     });
 
-    const p3 = hlfConnector.transact({
+    const p4 = hlfConnector.transact({
         signingCredential: signer,
         channelName: channelName,
         contractName: ccName,
@@ -102,7 +122,31 @@ async function mockEmissionsRecord() {
         ],
     });
 
-    await Promise.all([p1, p2, p3]);
+    const p5 = hlfConnector.transact({
+        signingCredential: signer,
+        channelName: channelName,
+        contractName: ccName,
+        invocationType: FabricContractInvocationType.Send,
+        methodName: 'importUtilityFactor',
+        params: [
+            'COUNTRY_DE_2019',
+            '2019',
+            'Germany',
+            'Country',
+            'Germany',
+            'Germany',
+            '',
+            '',
+            '338',
+            'g/KWH',
+            'https://www.eea.europa.eu/data-and-maps/data/approximated-estimates-for-the-share-4/eea-2017-res-share-proxies/2016-res_proxies_eea_csv/at_download/file;https://www.eea.europa.eu/data-and-maps/daviz/co2-emission-intensity-9',
+            '',
+            '',
+            '41.03',
+        ],
+    });
+
+    await Promise.all([p1, p2, p3, p4, p5]);
 }
 
 async function setupVault() {


### PR DESCRIPTION
This PR modifies the test setup script to insert emission factors for Germany, along with a utility identifier in the same region. Then, 2 emissions are recorded, one in the region of Germany, and the other in the US. Then we assert the following conditions:

- The emissions amounts of both years must not be equal
- The emissions amounts of each region should match the value calculated as per the emissions factors of that year
- In case of the emission recorded in Germany, the amounts of renewable and non-renewable energy must also match the values calculated as per the percent of renewables used in the region
- The emissions data is fetched from the CouchDB database using the HTTP /db/_find API. Then, the emissions factors are calculated and checked against the values stored on the ledger.

Closes #317.