### PR TITLE
Bump openzeppelin/contracts to 4.4.1

### DIFF
--- a/net-emissions-token-network/.openzeppelin/unknown-1337.json
+++ b/net-emissions-token-network/.openzeppelin/unknown-1337.json
@@ -279,9 +279,9 @@
         }
       }
     },
-    "98f81680dda1f54f822ebd1722aff23eabdd1f7be07c3c7c48315f834dc82f34": {
-      "address": "0x959922bE3CAee4b8Cd9a407cc3ac1C251C2007B1",
-      "txHash": "0x47ed57e9c57666894603cad8a6f9aa0ae03bbfd795d051a4e1ec074b4ea2b529",
+    "bb99dd4124c1e7832d123b08f5e52aea9e5a315451873c096cfffe6ded84aac3": {
+      "address": "0x68B1D87F95878fE05B998F19b66F4baba5De1aed",
+      "txHash": "0xfc38a504851c0e3868a4b6df48c2b5df62dc8f96283032c586c8b91e25420ec7",
       "layout": {
         "storage": [
           {
@@ -371,13 +371,13 @@
           {
             "contract": "NetEmissionsTokenNetworkV2",
             "label": "_numOfUniqueTokens",
-            "type": "t_struct(Counter)2327_storage",
+            "type": "t_struct(Counter)3609_storage",
             "src": "contracts/NetEmissionsTokenNetworkV2.sol:68"
           },
           {
             "contract": "NetEmissionsTokenNetworkV2",
             "label": "_tokenDetails",
-            "type": "t_mapping(t_uint256,t_struct(CarbonTokenDetails)4392_storage)",
+            "type": "t_mapping(t_uint256,t_struct(CarbonTokenDetails)7998_storage)",
             "src": "contracts/NetEmissionsTokenNetworkV2.sol:71"
           },
           {
@@ -388,9 +388,21 @@
           },
           {
             "contract": "NetEmissionsTokenNetworkV2",
+            "label": "_transferredBalances",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_uint256))",
+            "src": "contracts/NetEmissionsTokenNetworkV2.sol:73"
+          },
+          {
+            "contract": "NetEmissionsTokenNetworkV2",
+            "label": "carbonTransferNonce",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint32))",
+            "src": "contracts/NetEmissionsTokenNetworkV2.sol:76"
+          },
+          {
+            "contract": "NetEmissionsTokenNetworkV2",
             "label": "newTestVariable",
             "type": "t_address",
-            "src": "contracts/NetEmissionsTokenNetworkV2.sol:74"
+            "src": "contracts/NetEmissionsTokenNetworkV2.sol:78"
           }
         ],
         "types": {
@@ -400,7 +412,7 @@
           "t_address": {
             "label": "address"
           },
-          "t_struct(Counter)2327_storage": {
+          "t_struct(Counter)3609_storage": {
             "label": "struct CountersUpgradeable.Counter",
             "members": [
               {
@@ -412,10 +424,10 @@
           "t_uint256": {
             "label": "uint256"
           },
-          "t_mapping(t_uint256,t_struct(CarbonTokenDetails)4392_storage)": {
+          "t_mapping(t_uint256,t_struct(CarbonTokenDetails)7998_storage)": {
             "label": "mapping(uint256 => struct NetEmissionsTokenNetworkV2.CarbonTokenDetails)"
           },
-          "t_struct(CarbonTokenDetails)4392_storage": {
+          "t_struct(CarbonTokenDetails)7998_storage": {
             "label": "struct NetEmissionsTokenNetworkV2.CarbonTokenDetails",
             "members": [
               {
@@ -484,6 +496,15 @@
           "t_mapping(t_address,t_uint256)": {
             "label": "mapping(address => uint256)"
           },
+          "t_mapping(t_address,t_mapping(t_address,t_uint32))": {
+            "label": "mapping(address => mapping(address => uint32))"
+          },
+          "t_mapping(t_address,t_uint32)": {
+            "label": "mapping(address => uint32)"
+          },
+          "t_uint32": {
+            "label": "uint32"
+          },
           "t_mapping(t_bytes32,t_struct(RoleData)39_storage)": {
             "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)"
           },
@@ -495,7 +516,7 @@
             "members": [
               {
                 "label": "members",
-                "type": "t_struct(AddressSet)2643_storage"
+                "type": "t_struct(AddressSet)4485_storage"
               },
               {
                 "label": "adminRole",
@@ -503,16 +524,307 @@
               }
             ]
           },
-          "t_struct(AddressSet)2643_storage": {
+          "t_struct(AddressSet)4485_storage": {
             "label": "struct EnumerableSetUpgradeable.AddressSet",
             "members": [
               {
                 "label": "_inner",
-                "type": "t_struct(Set)2378_storage"
+                "type": "t_struct(Set)4220_storage"
               }
             ]
           },
-          "t_struct(Set)2378_storage": {
+          "t_struct(Set)4220_storage": {
+            "label": "struct EnumerableSetUpgradeable.Set",
+            "members": [
+              {
+                "label": "_values",
+                "type": "t_array(t_bytes32)dyn_storage"
+              },
+              {
+                "label": "_indexes",
+                "type": "t_mapping(t_bytes32,t_uint256)"
+              }
+            ]
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_bool))": {
+            "label": "mapping(address => mapping(address => bool))"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          },
+          "t_mapping(t_bytes4,t_bool)": {
+            "label": "mapping(bytes4 => bool)"
+          },
+          "t_bytes4": {
+            "label": "bytes4"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          }
+        }
+      }
+    },
+    "a27acc2827eacb13670e300f03ea976218045d464df85b3cf7ddd9fa5fd2833b": {
+      "address": "0x9A676e781A523b5d0C0e43731313A708CB607508",
+      "txHash": "0x1f6df861558b6d85eeec8904c7267e2219e01ee8b475159eee5370b36b963e3a",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol:25"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol:30"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:31"
+          },
+          {
+            "contract": "ERC165Upgradeable",
+            "label": "_supportedInterfaces",
+            "type": "t_mapping(t_bytes4,t_bool)",
+            "src": "@openzeppelin/contracts-upgradeable/introspection/ERC165Upgradeable.sol:23"
+          },
+          {
+            "contract": "ERC165Upgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/introspection/ERC165Upgradeable.sol:59"
+          },
+          {
+            "contract": "ERC1155Upgradeable",
+            "label": "_balances",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_uint256))",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol:27"
+          },
+          {
+            "contract": "ERC1155Upgradeable",
+            "label": "_operatorApprovals",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_bool))",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol:30"
+          },
+          {
+            "contract": "ERC1155Upgradeable",
+            "label": "_uri",
+            "type": "t_string_storage",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol:33"
+          },
+          {
+            "contract": "ERC1155Upgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol:421"
+          },
+          {
+            "contract": "AccessControlUpgradeable",
+            "label": "_roles",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)39_storage)",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61"
+          },
+          {
+            "contract": "AccessControlUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:225"
+          },
+          {
+            "contract": "NetEmissionsTokenNetwork",
+            "label": "limitedMode",
+            "type": "t_bool",
+            "src": "contracts/NetEmissionsTokenNetwork.sol:18"
+          },
+          {
+            "contract": "NetEmissionsTokenNetwork",
+            "label": "admin",
+            "type": "t_address",
+            "src": "contracts/NetEmissionsTokenNetwork.sol:19"
+          },
+          {
+            "contract": "NetEmissionsTokenNetwork",
+            "label": "timelock",
+            "type": "t_address",
+            "src": "contracts/NetEmissionsTokenNetwork.sol:20"
+          },
+          {
+            "contract": "NetEmissionsTokenNetwork",
+            "label": "_numOfUniqueTokens",
+            "type": "t_struct(Counter)3609_storage",
+            "src": "contracts/NetEmissionsTokenNetwork.sol:75"
+          },
+          {
+            "contract": "NetEmissionsTokenNetwork",
+            "label": "_tokenDetails",
+            "type": "t_mapping(t_uint256,t_struct(CarbonTokenDetails)6184_storage)",
+            "src": "contracts/NetEmissionsTokenNetwork.sol:78"
+          },
+          {
+            "contract": "NetEmissionsTokenNetwork",
+            "label": "_retiredBalances",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_uint256))",
+            "src": "contracts/NetEmissionsTokenNetwork.sol:79"
+          },
+          {
+            "contract": "NetEmissionsTokenNetwork",
+            "label": "_transferredBalances",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_uint256))",
+            "src": "contracts/NetEmissionsTokenNetwork.sol:80"
+          },
+          {
+            "contract": "NetEmissionsTokenNetwork",
+            "label": "carbonTransferNonce",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint32))",
+            "src": "contracts/NetEmissionsTokenNetwork.sol:83"
+          }
+        ],
+        "types": {
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_address": {
+            "label": "address"
+          },
+          "t_struct(Counter)3609_storage": {
+            "label": "struct CountersUpgradeable.Counter",
+            "members": [
+              {
+                "label": "_value",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_uint256,t_struct(CarbonTokenDetails)6184_storage)": {
+            "label": "mapping(uint256 => struct NetEmissionsTokenNetwork.CarbonTokenDetails)"
+          },
+          "t_struct(CarbonTokenDetails)6184_storage": {
+            "label": "struct NetEmissionsTokenNetwork.CarbonTokenDetails",
+            "members": [
+              {
+                "label": "tokenId",
+                "type": "t_uint256"
+              },
+              {
+                "label": "tokenTypeId",
+                "type": "t_uint8"
+              },
+              {
+                "label": "issuer",
+                "type": "t_address"
+              },
+              {
+                "label": "issuee",
+                "type": "t_address"
+              },
+              {
+                "label": "fromDate",
+                "type": "t_uint256"
+              },
+              {
+                "label": "thruDate",
+                "type": "t_uint256"
+              },
+              {
+                "label": "dateCreated",
+                "type": "t_uint256"
+              },
+              {
+                "label": "automaticRetireDate",
+                "type": "t_uint256"
+              },
+              {
+                "label": "metadata",
+                "type": "t_string_storage"
+              },
+              {
+                "label": "manifest",
+                "type": "t_string_storage"
+              },
+              {
+                "label": "description",
+                "type": "t_string_storage"
+              },
+              {
+                "label": "totalIssued",
+                "type": "t_uint256"
+              },
+              {
+                "label": "totalRetired",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_uint8": {
+            "label": "uint8"
+          },
+          "t_string_storage": {
+            "label": "string"
+          },
+          "t_mapping(t_uint256,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(uint256 => mapping(address => uint256))"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint32))": {
+            "label": "mapping(address => mapping(address => uint32))"
+          },
+          "t_mapping(t_address,t_uint32)": {
+            "label": "mapping(address => uint32)"
+          },
+          "t_uint32": {
+            "label": "uint32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)39_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)"
+          },
+          "t_bytes32": {
+            "label": "bytes32"
+          },
+          "t_struct(RoleData)39_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_struct(AddressSet)4485_storage"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32"
+              }
+            ]
+          },
+          "t_struct(AddressSet)4485_storage": {
+            "label": "struct EnumerableSetUpgradeable.AddressSet",
+            "members": [
+              {
+                "label": "_inner",
+                "type": "t_struct(Set)4220_storage"
+              }
+            ]
+          },
+          "t_struct(Set)4220_storage": {
             "label": "struct EnumerableSetUpgradeable.Set",
             "members": [
               {
@@ -557,7 +869,7 @@
     }
   },
   "admin": {
-    "address": "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
-    "txHash": "0xa3a88f156999365b04e205ff65a850710f17b6e3df74e06fee48f05f690fe445"
+    "address": "0x0B306BF915C4d645ff596e518fAf3F9669b97016",
+    "txHash": "0xdf41164269eb2141e1c6f864b1a3d83f9cceae810139768c99f8ec74057d2cb5"
   }
 }

--- a/net-emissions-token-network/.openzeppelin/unknown-1337.json
+++ b/net-emissions-token-network/.openzeppelin/unknown-1337.json
@@ -279,319 +279,22 @@
         }
       }
     },
-    "bb99dd4124c1e7832d123b08f5e52aea9e5a315451873c096cfffe6ded84aac3": {
-      "address": "0x68B1D87F95878fE05B998F19b66F4baba5De1aed",
-      "txHash": "0xfc38a504851c0e3868a4b6df48c2b5df62dc8f96283032c586c8b91e25420ec7",
-      "layout": {
-        "storage": [
-          {
-            "contract": "Initializable",
-            "label": "_initialized",
-            "type": "t_bool",
-            "src": "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol:25"
-          },
-          {
-            "contract": "Initializable",
-            "label": "_initializing",
-            "type": "t_bool",
-            "src": "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol:30"
-          },
-          {
-            "contract": "ContextUpgradeable",
-            "label": "__gap",
-            "type": "t_array(t_uint256)50_storage",
-            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:31"
-          },
-          {
-            "contract": "ERC165Upgradeable",
-            "label": "_supportedInterfaces",
-            "type": "t_mapping(t_bytes4,t_bool)",
-            "src": "@openzeppelin/contracts-upgradeable/introspection/ERC165Upgradeable.sol:23"
-          },
-          {
-            "contract": "ERC165Upgradeable",
-            "label": "__gap",
-            "type": "t_array(t_uint256)49_storage",
-            "src": "@openzeppelin/contracts-upgradeable/introspection/ERC165Upgradeable.sol:59"
-          },
-          {
-            "contract": "ERC1155Upgradeable",
-            "label": "_balances",
-            "type": "t_mapping(t_uint256,t_mapping(t_address,t_uint256))",
-            "src": "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol:27"
-          },
-          {
-            "contract": "ERC1155Upgradeable",
-            "label": "_operatorApprovals",
-            "type": "t_mapping(t_address,t_mapping(t_address,t_bool))",
-            "src": "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol:30"
-          },
-          {
-            "contract": "ERC1155Upgradeable",
-            "label": "_uri",
-            "type": "t_string_storage",
-            "src": "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol:33"
-          },
-          {
-            "contract": "ERC1155Upgradeable",
-            "label": "__gap",
-            "type": "t_array(t_uint256)47_storage",
-            "src": "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol:421"
-          },
-          {
-            "contract": "AccessControlUpgradeable",
-            "label": "_roles",
-            "type": "t_mapping(t_bytes32,t_struct(RoleData)39_storage)",
-            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61"
-          },
-          {
-            "contract": "AccessControlUpgradeable",
-            "label": "__gap",
-            "type": "t_array(t_uint256)49_storage",
-            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:225"
-          },
-          {
-            "contract": "NetEmissionsTokenNetworkV2",
-            "label": "limitedMode",
-            "type": "t_bool",
-            "src": "contracts/NetEmissionsTokenNetworkV2.sol:19"
-          },
-          {
-            "contract": "NetEmissionsTokenNetworkV2",
-            "label": "admin",
-            "type": "t_address",
-            "src": "contracts/NetEmissionsTokenNetworkV2.sol:20"
-          },
-          {
-            "contract": "NetEmissionsTokenNetworkV2",
-            "label": "timelock",
-            "type": "t_address",
-            "src": "contracts/NetEmissionsTokenNetworkV2.sol:21"
-          },
-          {
-            "contract": "NetEmissionsTokenNetworkV2",
-            "label": "_numOfUniqueTokens",
-            "type": "t_struct(Counter)3609_storage",
-            "src": "contracts/NetEmissionsTokenNetworkV2.sol:68"
-          },
-          {
-            "contract": "NetEmissionsTokenNetworkV2",
-            "label": "_tokenDetails",
-            "type": "t_mapping(t_uint256,t_struct(CarbonTokenDetails)7998_storage)",
-            "src": "contracts/NetEmissionsTokenNetworkV2.sol:71"
-          },
-          {
-            "contract": "NetEmissionsTokenNetworkV2",
-            "label": "_retiredBalances",
-            "type": "t_mapping(t_uint256,t_mapping(t_address,t_uint256))",
-            "src": "contracts/NetEmissionsTokenNetworkV2.sol:72"
-          },
-          {
-            "contract": "NetEmissionsTokenNetworkV2",
-            "label": "_transferredBalances",
-            "type": "t_mapping(t_uint256,t_mapping(t_address,t_uint256))",
-            "src": "contracts/NetEmissionsTokenNetworkV2.sol:73"
-          },
-          {
-            "contract": "NetEmissionsTokenNetworkV2",
-            "label": "carbonTransferNonce",
-            "type": "t_mapping(t_address,t_mapping(t_address,t_uint32))",
-            "src": "contracts/NetEmissionsTokenNetworkV2.sol:76"
-          },
-          {
-            "contract": "NetEmissionsTokenNetworkV2",
-            "label": "newTestVariable",
-            "type": "t_address",
-            "src": "contracts/NetEmissionsTokenNetworkV2.sol:78"
-          }
-        ],
-        "types": {
-          "t_bool": {
-            "label": "bool"
-          },
-          "t_address": {
-            "label": "address"
-          },
-          "t_struct(Counter)3609_storage": {
-            "label": "struct CountersUpgradeable.Counter",
-            "members": [
-              {
-                "label": "_value",
-                "type": "t_uint256"
-              }
-            ]
-          },
-          "t_uint256": {
-            "label": "uint256"
-          },
-          "t_mapping(t_uint256,t_struct(CarbonTokenDetails)7998_storage)": {
-            "label": "mapping(uint256 => struct NetEmissionsTokenNetworkV2.CarbonTokenDetails)"
-          },
-          "t_struct(CarbonTokenDetails)7998_storage": {
-            "label": "struct NetEmissionsTokenNetworkV2.CarbonTokenDetails",
-            "members": [
-              {
-                "label": "tokenId",
-                "type": "t_uint256"
-              },
-              {
-                "label": "tokenTypeId",
-                "type": "t_uint8"
-              },
-              {
-                "label": "issuer",
-                "type": "t_address"
-              },
-              {
-                "label": "issuee",
-                "type": "t_address"
-              },
-              {
-                "label": "fromDate",
-                "type": "t_uint256"
-              },
-              {
-                "label": "thruDate",
-                "type": "t_uint256"
-              },
-              {
-                "label": "dateCreated",
-                "type": "t_uint256"
-              },
-              {
-                "label": "automaticRetireDate",
-                "type": "t_uint256"
-              },
-              {
-                "label": "metadata",
-                "type": "t_string_storage"
-              },
-              {
-                "label": "manifest",
-                "type": "t_string_storage"
-              },
-              {
-                "label": "description",
-                "type": "t_string_storage"
-              },
-              {
-                "label": "totalIssued",
-                "type": "t_uint256"
-              },
-              {
-                "label": "totalRetired",
-                "type": "t_uint256"
-              }
-            ]
-          },
-          "t_uint8": {
-            "label": "uint8"
-          },
-          "t_string_storage": {
-            "label": "string"
-          },
-          "t_mapping(t_uint256,t_mapping(t_address,t_uint256))": {
-            "label": "mapping(uint256 => mapping(address => uint256))"
-          },
-          "t_mapping(t_address,t_uint256)": {
-            "label": "mapping(address => uint256)"
-          },
-          "t_mapping(t_address,t_mapping(t_address,t_uint32))": {
-            "label": "mapping(address => mapping(address => uint32))"
-          },
-          "t_mapping(t_address,t_uint32)": {
-            "label": "mapping(address => uint32)"
-          },
-          "t_uint32": {
-            "label": "uint32"
-          },
-          "t_mapping(t_bytes32,t_struct(RoleData)39_storage)": {
-            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)"
-          },
-          "t_bytes32": {
-            "label": "bytes32"
-          },
-          "t_struct(RoleData)39_storage": {
-            "label": "struct AccessControlUpgradeable.RoleData",
-            "members": [
-              {
-                "label": "members",
-                "type": "t_struct(AddressSet)4485_storage"
-              },
-              {
-                "label": "adminRole",
-                "type": "t_bytes32"
-              }
-            ]
-          },
-          "t_struct(AddressSet)4485_storage": {
-            "label": "struct EnumerableSetUpgradeable.AddressSet",
-            "members": [
-              {
-                "label": "_inner",
-                "type": "t_struct(Set)4220_storage"
-              }
-            ]
-          },
-          "t_struct(Set)4220_storage": {
-            "label": "struct EnumerableSetUpgradeable.Set",
-            "members": [
-              {
-                "label": "_values",
-                "type": "t_array(t_bytes32)dyn_storage"
-              },
-              {
-                "label": "_indexes",
-                "type": "t_mapping(t_bytes32,t_uint256)"
-              }
-            ]
-          },
-          "t_array(t_bytes32)dyn_storage": {
-            "label": "bytes32[]"
-          },
-          "t_mapping(t_bytes32,t_uint256)": {
-            "label": "mapping(bytes32 => uint256)"
-          },
-          "t_array(t_uint256)49_storage": {
-            "label": "uint256[49]"
-          },
-          "t_mapping(t_address,t_mapping(t_address,t_bool))": {
-            "label": "mapping(address => mapping(address => bool))"
-          },
-          "t_mapping(t_address,t_bool)": {
-            "label": "mapping(address => bool)"
-          },
-          "t_array(t_uint256)47_storage": {
-            "label": "uint256[47]"
-          },
-          "t_mapping(t_bytes4,t_bool)": {
-            "label": "mapping(bytes4 => bool)"
-          },
-          "t_bytes4": {
-            "label": "bytes4"
-          },
-          "t_array(t_uint256)50_storage": {
-            "label": "uint256[50]"
-          }
-        }
-      }
-    },
-    "a27acc2827eacb13670e300f03ea976218045d464df85b3cf7ddd9fa5fd2833b": {
+    "a3dab96e0916b05f98a71c750e1bdcb1d640a005796c713c48c1d0c1cd85cea4": {
       "address": "0x9A676e781A523b5d0C0e43731313A708CB607508",
-      "txHash": "0x1f6df861558b6d85eeec8904c7267e2219e01ee8b475159eee5370b36b963e3a",
+      "txHash": "0xa1a3d4c9fba4fd3e2a69b69297aca2ac41bb8995c86e6c879cd91696b0e6e48e",
       "layout": {
         "storage": [
           {
             "contract": "Initializable",
             "label": "_initialized",
             "type": "t_bool",
-            "src": "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol:25"
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
           },
           {
             "contract": "Initializable",
             "label": "_initializing",
             "type": "t_bool",
-            "src": "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol:30"
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
           },
           {
             "contract": "ContextUpgradeable",
@@ -601,51 +304,45 @@
           },
           {
             "contract": "ERC165Upgradeable",
-            "label": "_supportedInterfaces",
-            "type": "t_mapping(t_bytes4,t_bool)",
-            "src": "@openzeppelin/contracts-upgradeable/introspection/ERC165Upgradeable.sol:23"
-          },
-          {
-            "contract": "ERC165Upgradeable",
             "label": "__gap",
-            "type": "t_array(t_uint256)49_storage",
-            "src": "@openzeppelin/contracts-upgradeable/introspection/ERC165Upgradeable.sol:59"
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:36"
           },
           {
             "contract": "ERC1155Upgradeable",
             "label": "_balances",
             "type": "t_mapping(t_uint256,t_mapping(t_address,t_uint256))",
-            "src": "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol:27"
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol:25"
           },
           {
             "contract": "ERC1155Upgradeable",
             "label": "_operatorApprovals",
             "type": "t_mapping(t_address,t_mapping(t_address,t_bool))",
-            "src": "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol:30"
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol:28"
           },
           {
             "contract": "ERC1155Upgradeable",
             "label": "_uri",
             "type": "t_string_storage",
-            "src": "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol:33"
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol:31"
           },
           {
             "contract": "ERC1155Upgradeable",
             "label": "__gap",
             "type": "t_array(t_uint256)47_storage",
-            "src": "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol:421"
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol:471"
           },
           {
             "contract": "AccessControlUpgradeable",
             "label": "_roles",
-            "type": "t_mapping(t_bytes32,t_struct(RoleData)39_storage)",
-            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61"
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)43_storage)",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:64"
           },
           {
             "contract": "AccessControlUpgradeable",
             "label": "__gap",
             "type": "t_array(t_uint256)49_storage",
-            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:225"
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:232"
           },
           {
             "contract": "NetEmissionsTokenNetwork",
@@ -668,13 +365,13 @@
           {
             "contract": "NetEmissionsTokenNetwork",
             "label": "_numOfUniqueTokens",
-            "type": "t_struct(Counter)3609_storage",
+            "type": "t_struct(Counter)3101_storage",
             "src": "contracts/NetEmissionsTokenNetwork.sol:75"
           },
           {
             "contract": "NetEmissionsTokenNetwork",
             "label": "_tokenDetails",
-            "type": "t_mapping(t_uint256,t_struct(CarbonTokenDetails)6184_storage)",
+            "type": "t_mapping(t_uint256,t_struct(CarbonTokenDetails)5566_storage)",
             "src": "contracts/NetEmissionsTokenNetwork.sol:78"
           },
           {
@@ -703,7 +400,7 @@
           "t_address": {
             "label": "address"
           },
-          "t_struct(Counter)3609_storage": {
+          "t_struct(Counter)3101_storage": {
             "label": "struct CountersUpgradeable.Counter",
             "members": [
               {
@@ -715,10 +412,10 @@
           "t_uint256": {
             "label": "uint256"
           },
-          "t_mapping(t_uint256,t_struct(CarbonTokenDetails)6184_storage)": {
+          "t_mapping(t_uint256,t_struct(CarbonTokenDetails)5566_storage)": {
             "label": "mapping(uint256 => struct NetEmissionsTokenNetwork.CarbonTokenDetails)"
           },
-          "t_struct(CarbonTokenDetails)6184_storage": {
+          "t_struct(CarbonTokenDetails)5566_storage": {
             "label": "struct NetEmissionsTokenNetwork.CarbonTokenDetails",
             "members": [
               {
@@ -796,18 +493,18 @@
           "t_uint32": {
             "label": "uint32"
           },
-          "t_mapping(t_bytes32,t_struct(RoleData)39_storage)": {
+          "t_mapping(t_bytes32,t_struct(RoleData)43_storage)": {
             "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)"
           },
           "t_bytes32": {
             "label": "bytes32"
           },
-          "t_struct(RoleData)39_storage": {
+          "t_struct(RoleData)43_storage": {
             "label": "struct AccessControlUpgradeable.RoleData",
             "members": [
               {
                 "label": "members",
-                "type": "t_struct(AddressSet)4485_storage"
+                "type": "t_mapping(t_address,t_bool)"
               },
               {
                 "label": "adminRole",
@@ -815,33 +512,8 @@
               }
             ]
           },
-          "t_struct(AddressSet)4485_storage": {
-            "label": "struct EnumerableSetUpgradeable.AddressSet",
-            "members": [
-              {
-                "label": "_inner",
-                "type": "t_struct(Set)4220_storage"
-              }
-            ]
-          },
-          "t_struct(Set)4220_storage": {
-            "label": "struct EnumerableSetUpgradeable.Set",
-            "members": [
-              {
-                "label": "_values",
-                "type": "t_array(t_bytes32)dyn_storage"
-              },
-              {
-                "label": "_indexes",
-                "type": "t_mapping(t_bytes32,t_uint256)"
-              }
-            ]
-          },
-          "t_array(t_bytes32)dyn_storage": {
-            "label": "bytes32[]"
-          },
-          "t_mapping(t_bytes32,t_uint256)": {
-            "label": "mapping(bytes32 => uint256)"
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)"
           },
           "t_array(t_uint256)49_storage": {
             "label": "uint256[49]"
@@ -849,17 +521,265 @@
           "t_mapping(t_address,t_mapping(t_address,t_bool))": {
             "label": "mapping(address => mapping(address => bool))"
           },
-          "t_mapping(t_address,t_bool)": {
-            "label": "mapping(address => bool)"
-          },
           "t_array(t_uint256)47_storage": {
             "label": "uint256[47]"
           },
-          "t_mapping(t_bytes4,t_bool)": {
-            "label": "mapping(bytes4 => bool)"
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          }
+        }
+      }
+    },
+    "9262d7bbbc8c15b472f3e5ef288d8d536ae132661ff264c1f68eb0bc756f92dd": {
+      "address": "0x68B1D87F95878fE05B998F19b66F4baba5De1aed",
+      "txHash": "0x290de47b68acb6835d841e2a7c1014ad6d2bb2aeefd71b677b39a54980626bb8",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
           },
-          "t_bytes4": {
-            "label": "bytes4"
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:31"
+          },
+          {
+            "contract": "ERC165Upgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:36"
+          },
+          {
+            "contract": "ERC1155Upgradeable",
+            "label": "_balances",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_uint256))",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol:25"
+          },
+          {
+            "contract": "ERC1155Upgradeable",
+            "label": "_operatorApprovals",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_bool))",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol:28"
+          },
+          {
+            "contract": "ERC1155Upgradeable",
+            "label": "_uri",
+            "type": "t_string_storage",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol:31"
+          },
+          {
+            "contract": "ERC1155Upgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol:471"
+          },
+          {
+            "contract": "AccessControlUpgradeable",
+            "label": "_roles",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)43_storage)",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:64"
+          },
+          {
+            "contract": "AccessControlUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:232"
+          },
+          {
+            "contract": "NetEmissionsTokenNetworkV2",
+            "label": "limitedMode",
+            "type": "t_bool",
+            "src": "contracts/NetEmissionsTokenNetworkV2.sol:19"
+          },
+          {
+            "contract": "NetEmissionsTokenNetworkV2",
+            "label": "admin",
+            "type": "t_address",
+            "src": "contracts/NetEmissionsTokenNetworkV2.sol:20"
+          },
+          {
+            "contract": "NetEmissionsTokenNetworkV2",
+            "label": "timelock",
+            "type": "t_address",
+            "src": "contracts/NetEmissionsTokenNetworkV2.sol:21"
+          },
+          {
+            "contract": "NetEmissionsTokenNetworkV2",
+            "label": "_numOfUniqueTokens",
+            "type": "t_struct(Counter)3101_storage",
+            "src": "contracts/NetEmissionsTokenNetworkV2.sol:68"
+          },
+          {
+            "contract": "NetEmissionsTokenNetworkV2",
+            "label": "_tokenDetails",
+            "type": "t_mapping(t_uint256,t_struct(CarbonTokenDetails)7410_storage)",
+            "src": "contracts/NetEmissionsTokenNetworkV2.sol:71"
+          },
+          {
+            "contract": "NetEmissionsTokenNetworkV2",
+            "label": "_retiredBalances",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_uint256))",
+            "src": "contracts/NetEmissionsTokenNetworkV2.sol:72"
+          },
+          {
+            "contract": "NetEmissionsTokenNetworkV2",
+            "label": "_transferredBalances",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_uint256))",
+            "src": "contracts/NetEmissionsTokenNetworkV2.sol:73"
+          },
+          {
+            "contract": "NetEmissionsTokenNetworkV2",
+            "label": "carbonTransferNonce",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint32))",
+            "src": "contracts/NetEmissionsTokenNetworkV2.sol:76"
+          },
+          {
+            "contract": "NetEmissionsTokenNetworkV2",
+            "label": "newTestVariable",
+            "type": "t_address",
+            "src": "contracts/NetEmissionsTokenNetworkV2.sol:78"
+          }
+        ],
+        "types": {
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_address": {
+            "label": "address"
+          },
+          "t_struct(Counter)3101_storage": {
+            "label": "struct CountersUpgradeable.Counter",
+            "members": [
+              {
+                "label": "_value",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_uint256,t_struct(CarbonTokenDetails)7410_storage)": {
+            "label": "mapping(uint256 => struct NetEmissionsTokenNetworkV2.CarbonTokenDetails)"
+          },
+          "t_struct(CarbonTokenDetails)7410_storage": {
+            "label": "struct NetEmissionsTokenNetworkV2.CarbonTokenDetails",
+            "members": [
+              {
+                "label": "tokenId",
+                "type": "t_uint256"
+              },
+              {
+                "label": "tokenTypeId",
+                "type": "t_uint8"
+              },
+              {
+                "label": "issuer",
+                "type": "t_address"
+              },
+              {
+                "label": "issuee",
+                "type": "t_address"
+              },
+              {
+                "label": "fromDate",
+                "type": "t_uint256"
+              },
+              {
+                "label": "thruDate",
+                "type": "t_uint256"
+              },
+              {
+                "label": "dateCreated",
+                "type": "t_uint256"
+              },
+              {
+                "label": "automaticRetireDate",
+                "type": "t_uint256"
+              },
+              {
+                "label": "metadata",
+                "type": "t_string_storage"
+              },
+              {
+                "label": "manifest",
+                "type": "t_string_storage"
+              },
+              {
+                "label": "description",
+                "type": "t_string_storage"
+              },
+              {
+                "label": "totalIssued",
+                "type": "t_uint256"
+              },
+              {
+                "label": "totalRetired",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_uint8": {
+            "label": "uint8"
+          },
+          "t_string_storage": {
+            "label": "string"
+          },
+          "t_mapping(t_uint256,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(uint256 => mapping(address => uint256))"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint32))": {
+            "label": "mapping(address => mapping(address => uint32))"
+          },
+          "t_mapping(t_address,t_uint32)": {
+            "label": "mapping(address => uint32)"
+          },
+          "t_uint32": {
+            "label": "uint32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)43_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)"
+          },
+          "t_bytes32": {
+            "label": "bytes32"
+          },
+          "t_struct(RoleData)43_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_bool))": {
+            "label": "mapping(address => mapping(address => bool))"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
           },
           "t_array(t_uint256)50_storage": {
             "label": "uint256[50]"

--- a/net-emissions-token-network/contracts/Governance/CarbonTracker.sol
+++ b/net-emissions-token-network/contracts/Governance/CarbonTracker.sol
@@ -1,0 +1,424 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+import "../NetEmissionsTokenNetwork.sol";
+import "@openzeppelin/contracts-upgradeable/math/SafeMathUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol";
+
+contract CarbonTracker is Initializable, ERC721Upgradeable, AccessControlUpgradeable {
+
+    using SafeMathUpgradeable for uint256;
+    using CountersUpgradeable for CountersUpgradeable.Counter;
+
+    NetEmissionsTokenNetwork net;
+
+    // Registered Tracker
+    bytes32 public constant REGISTERED_TRACKER =
+        keccak256("REGISTERED_TRACKER");
+    /**
+     * @dev tracker struct for incoming/ outgoing carbon tokens of the tracker
+     * tokenId - array of ids of carbon tokens (direct/indirect/offsets)
+     * idIndex - mapping tokenId to its index in array. index starts at 1 and 0 reserved for unindexed tokens
+     * idAmount - mapping tokenId to an amount
+     * idAudit - address that audited this token
+    **/
+    struct CarbonTrackerTokens{
+        uint256[] tokenIds;
+        mapping(uint => uint) idIndex; 
+        mapping(uint => uint) idAmount;
+        // TO-DO introduce idAudit for each token?
+        // TO-DO if idAudit is market true should we prevent further update?
+        // TO-DO introduce audit conflict if requesting update to audited tokenId?
+        // NOTE: for now we can check if tracker update was submited by auditor from
+        // the TrackerUpdated event
+        //mapping(uint => address) idAudit; 
+    }
+
+    /**
+     * @dev tracker details
+     * trackee - address of the account the tracking will apply to
+     * carbonIn - token inputs (i.e. direct indirect emissions)
+     * carbonOut - token outputs (i.e unrealized emission transfers or indirect emissions)
+     * trackerId - mapping tokenId (in) to another trackerId for embodied emission tracing
+    **/
+    struct CarbonTrackerDetails {
+        //uint256 trackerId;
+        address trackee;    
+        address auditor;    
+        uint totalEmissions;
+        uint totalAudited;
+
+        CarbonTrackerTokens carbonIn;
+        CarbonTrackerTokens carbonOut;
+        //tokenId into previous trackerId (token type 4)
+        mapping(uint => uint) trackerId;
+        //tokenId into aggregate amounts tracked into other tracker tokens
+        mapping(uint => uint) totalIn;
+
+    }
+    // mappings for carbon tracking data
+    mapping(uint256 => CarbonTrackerDetails) private _trackerData;
+    // retired balances of tokenId tracked to address trackee
+    mapping(uint256 => mapping(address => uint256)) private _retiredBalances; 
+    // transferredBalances balances of tokenId tracked to address trackee
+    mapping(uint256 => mapping(address => uint256)) private _transferredBalances; 
+
+    // map audited emission tokens into a trackerId 
+    mapping(uint => uint) auditedTrackerId;
+
+    // map auditor to trackee
+    mapping(address => mapping (address => bool)) isAuditorApproved;
+
+    // Counts number of unique token IDs (auto-incrementing)
+    CountersUpgradeable.Counter private _numOfUniqueTrackers;
+
+    event RegisteredTracker(address indexed account);
+    event TrackerUpdated(
+        uint256 indexed trackerId,
+        address indexed tracker,
+        uint256[] inIds,
+        uint256[] inAmounts,
+        uint256[] outIds,
+        uint256[] outAmounts,
+        uint256[] trackerIds);
+    event TrackeeChanged(uint indexed trackerId, address indexed trackee);
+    event AuditorApproved(address indexed auditor,address indexed trackee);
+    event AuditorRemoved(address indexed auditor,address indexed trackee);
+
+
+    function initialize(address _net, address _admin) public initializer {
+        net = NetEmissionsTokenNetwork(_net);
+        __ERC721_init('NET Carbon Tracker', "NETT");
+        _setupRole(DEFAULT_ADMIN_ROLE, _admin);
+        _setupRole(REGISTERED_TRACKER, _admin);
+    }  
+    modifier notSender(address auditor){
+        require(auditor!=msg.sender,
+            "CLM8::notSender: auditor cannot be msg.sender");
+        _;
+    }
+    /**
+     * @dev msg.sender is trackee or approved auditor of trackee
+     * @param trackerId - target trackerId
+     */
+    modifier trackerOrAuditor(uint trackerId) {
+        require(
+            ( msg.sender == _trackerData[trackerId].trackee &&          
+              hasRole(REGISTERED_TRACKER, _trackerData[trackerId].trackee)) ||
+            isAuditorApproved[msg.sender][_trackerData[trackerId].trackee],
+            "CLM8::trackerOrAuditor: msg.sender must be a registered tracker or approved auditor of the trackee"
+        );
+        _;
+    }
+    modifier notAudited(uint trackerId){
+        require(_trackerData[trackerId].auditor==address(0),
+            "CLM8::notAudited: trackerId is already audited"
+        );
+        _;
+    }
+    modifier isAuditor(uint trackerId){
+        _isAuditor(trackerId);
+        _;
+    }
+    function _isAuditor(uint trackerId) view internal{
+        require(isAuditorApproved[msg.sender][_trackerData[trackerId].trackee],
+            "CLM8::isAuditor: auditor is not approved by the trackee");
+    }
+    modifier trackerTokenkExists(uint256 tokenId){
+        require(_numOfUniqueTrackers.current() >= tokenId,
+            "CLM8::trackerTokenkExists: tracker token ID does not exist");
+        _;
+    }
+    modifier registeredTracker(address trackee){
+        require(hasRole(REGISTERED_TRACKER, trackee),
+            "CLM8::registeredTracker: the address is not registered");
+        _;
+    }
+    modifier onlyAdmin() {         
+        require(hasRole(DEFAULT_ADMIN_ROLE, msg.sender),
+            "CLM8::onlyAdmin: msg.sender is not an admin");
+        _;
+    }
+    /**
+     * @dev require msg.sender has admin role
+     */
+    modifier selfOrAdmin(address _address){
+        require( _address==msg.sender || hasRole(DEFAULT_ADMIN_ROLE, msg.sender),
+            "CLM8::selfOrAdmin: msg.sender does not own this address or is not an admin");               
+        _;
+    }
+    modifier equalLength(uint[] memory arrayOne, uint[] memory arrrayTwo){
+        require(arrayOne.length == arrrayTwo.length, 
+            "CLM8::_equalLength: array lengths are not equal"); 
+        _;
+    }
+    /**
+     * @dev msg.sender is trackee or approved auditor of trackee
+     * @param trackee - target adress to be tracked
+     * @param inIds - array of ids of incoming carbon tokens (direct/indirect/offsets)
+     * @param inAmounts - array of incoming token idAmount (direct/indirect/offsets) matching each carbon token
+     * @param trackerIds - array of trackerIDs matching each tokenID for tracing embodied emissions 
+     * @param outIds - array of ids of outgoing carbon tokens (direct/indirect/offsets)
+     * @param outAmounts - array of outgoing token idAmount (direct/indirect emissions) matching each carbon token
+     */
+    function track(
+        address trackee,
+        uint256[] memory inIds,
+        uint256[] memory inAmounts,
+        uint256[] memory outIds,
+        uint256[] memory outAmounts,
+        uint256[] memory trackerIds) 
+        public {
+        // increment trackerId
+        _numOfUniqueTrackers.increment();
+        uint256 trackerId = _numOfUniqueTrackers.current();
+        // create token details
+        CarbonTrackerDetails storage trackerData = _trackerData[trackerId];
+        trackerData.trackee = trackee;
+        _track(trackerId,inIds,inAmounts,outIds,outAmounts,trackerIds);
+        super._mint(msg.sender,trackerId);
+    }
+
+    function trackUpdate(
+        uint256 trackerId,
+        uint256[] memory inIds,
+        uint256[] memory inAmounts,
+        uint256[] memory outIds,
+        uint256[] memory outAmounts,
+        uint256[] memory trackerIds) public trackerTokenkExists(trackerId) {
+        _track(trackerId,inIds,inAmounts,outIds,outAmounts,trackerIds);
+    }
+    function _track(
+        uint256 _trackerId,
+        uint256[] memory inIds,
+        uint256[] memory inAmounts,
+        uint256[] memory outIds,
+        uint256[] memory outAmounts,
+        uint256[] memory trackerIds) internal 
+        notAudited(_trackerId)
+        {
+        require(inAmounts.length == inIds.length, 
+            "CLM8::_equalLength: inAmounts and inIds lengths are not equal"); 
+        require(outAmounts.length == outIds.length, 
+            "CLM8::_equalLength: outAmounts and outIds lengths are not equal"); 
+        require(trackerIds.length == 0 || trackerIds.length == inIds.length, 
+            "CLM8::_track: length of carbonIn TrackerIds do not match the IDs");
+        // create token details
+        CarbonTrackerDetails storage trackerData = _trackerData[_trackerId];
+        require(
+            ( msg.sender == trackerData.trackee &&          
+              hasRole(REGISTERED_TRACKER, trackerData.trackee)) ||
+            isAuditorApproved[msg.sender][trackerData.trackee],
+            "CLM8::trackerOrAuditor: msg.sender must be a registered tracker or approved auditor of the trackee"
+        );
+
+        CarbonTrackerTokens storage carbonTrackerIn = trackerData.carbonIn; 
+        uint8 tokenTypeId;
+        for (uint i = 0; i < inIds.length; i++) { 
+            tokenTypeId = net.getTokenTypeId(inIds[i]);
+            // validate retired emissions and set total emissions
+            trackerData.totalEmissions = 
+                _verifyRetired(inIds[i], trackerData.trackee, tokenTypeId,
+                    carbonTrackerIn.idAmount[inIds[i]], inAmounts[i],
+                    trackerData.totalEmissions);
+            // asign trackerIds only for tokenTypeId==4
+            // Note audited emission tokens are mapped in auditedTrackerId 
+            if(trackerIds.length>0 && tokenTypeId==4){ 
+                _setTrackerId(trackerData,
+                    trackerIds[i],inIds[i],inAmounts[inIds[i]]);
+            }
+            _update(carbonTrackerIn,inIds[i],inAmounts[i]);
+        }
+        // collect token details
+        CarbonTrackerTokens storage carbonTrackerOut = trackerData.carbonOut;
+        for (uint i = 0; i < outIds.length; i++) { 
+            tokenTypeId = net.getTokenTypeId(outIds[i]);
+            if(tokenTypeId==4){
+                _verifyTransferred(outIds[i],trackerData.trackee,
+                    carbonTrackerOut.idAmount[outIds[i]],outAmounts[i]);  
+            }else if(tokenTypeId==3){
+                // to assign sudited emissions as outgoing carbon tracker must be an auditor
+                // TO-DO use trackerId and associated tx hahses as inputs for the Fabric
+                // emissions auditing channel
+                // In addition to issuing a retired audited emisison token to issuee
+                // the trackerId of the source industry will be updated with the audited emission as an output
+                // If the issuee is an industry that has volunteered to be tracked by the auditor
+                // a new trackerId could be issued with the audited emissions as an input
+                _isAuditor(_trackerId);
+                if(carbonTrackerOut.idAmount[outIds[i]]>0){
+                    trackerData.totalAudited = 
+                        trackerData.totalAudited.sub(carbonTrackerOut.idAmount[outIds[i]]);
+                }
+                if(outAmounts[i]>0){
+                    trackerData.totalAudited = 
+                        trackerData.totalAudited.add(outAmounts[i]);
+                    require(trackerData.totalEmissions>=trackerData.totalAudited,
+                        "CLM8::_track: total audited emission out is greater than total emission tracked");
+                    auditedTrackerId[outIds[i]]=_trackerId;        
+                }else{
+                    // if removing the amount completly delete the tracker mapping.
+                    delete auditedTrackerId[outIds[i]];
+                }
+            }else{
+                revert("CLM8::_track: can not track outgoin offsets or RECs");
+            }         
+            _update(carbonTrackerOut,outIds[i],outAmounts[i]);//,_isAuditor);
+        }   
+        emit TrackerUpdated(_trackerId,msg.sender,
+            inIds,inAmounts,outIds,outAmounts,trackerIds);
+    } 
+
+
+    function _setTrackerId(CarbonTrackerDetails storage trackerData, 
+        uint trackerId, uint tokenId, uint amount) internal {
+        // correct for previous amount assigned to the tokenId
+        CarbonTrackerDetails storage sourceTracker = _trackerData[trackerId];
+        if(trackerData.carbonIn.idAmount[tokenId]>0){
+            sourceTracker.totalIn[tokenId] = sourceTracker.totalIn[tokenId]
+                .sub(trackerData.carbonIn.idAmount[tokenId]);
+        }
+        if(amount>0){
+            sourceTracker.totalIn[tokenId] = 
+                sourceTracker.totalIn[tokenId].add(amount);
+            require(
+                sourceTracker.carbonOut.idAmount[tokenId] >=
+                    sourceTracker.totalIn[tokenId],
+                "CLM8::_track: total tracked in exceeds token output of trackerId"
+            );
+            trackerData.trackerId[tokenId]=trackerId;
+        }else{
+            delete trackerData.trackerId[tokenId];
+        }
+    }
+
+    /**
+     * @dev update the token data within the Tacker
+     * @
+     * @param tokenId - to be updated
+     * @param amount - amount asigned to tokenId
+    **/
+    function _update(
+        CarbonTrackerTokens storage _tokenData,
+        uint tokenId,
+        uint amount
+        //bool _isAuditor
+        ) internal {
+
+        uint index = _tokenData.idIndex[tokenId];
+        if(amount>0){
+            // if the final amount is not zero check if the tokenId should be
+            // added to the tokenIds array and update idAmount
+            //_tokenData.idAudit[tokenId] = _isAuditor;
+            if(index==0){
+                _tokenData.tokenIds.push(tokenId);
+                _tokenData.idIndex[tokenId]=_tokenData.tokenIds.length;
+            }
+            _tokenData.idAmount[tokenId] = amount;  
+        }else{
+            // remove tokenId and associated data from tracker
+            if (_tokenData.tokenIds.length > 1) {
+                _tokenData.tokenIds[index-1] = 
+                    _tokenData.tokenIds[_tokenData.tokenIds.length-1];
+                _tokenData.idIndex[_tokenData.tokenIds[index-1]]=index;
+            }
+            // index of tokenId should be deleted;
+            delete _tokenData.idIndex[tokenId];
+            delete _tokenData.idAmount[tokenId];
+            //delete _tokenData.idAudit[tokenId]
+            delete _tokenData.tokenIds[_tokenData.tokenIds.length-1];
+            //_tokenData.tokenIds.length--; // Implicitly recovers gas from last element storage
+        }
+    }
+
+    function _verifyRetired(uint tokenId,address trackee, uint8 tokenTypeId,
+        uint amountOld, uint amountNew, uint total) internal returns(uint) {
+        if(amountOld>0){
+            //adjust existing _retiredBalances
+            _retiredBalances[tokenId][trackee]
+                 =_retiredBalances[tokenId][trackee].sub(amountOld);
+            if(tokenTypeId>2){
+                total = total.sub(amountOld);
+            }else if(tokenTypeId==2){
+                total = total.add(amountOld);
+            }// REC does not change the total emissions
+        }
+        if(amountNew>0){
+            _retiredBalances[tokenId][trackee]=
+                _retiredBalances[tokenId][trackee].add(amountNew);
+            if(tokenTypeId>2){ //add in emission
+                total = total.add(amountOld);
+            }else if(tokenTypeId==2){ //subtract out offset
+                total = total.sub(amountOld);
+            }// else REC does not change the total emissions
+            require(
+                net.getRetiredBalances(tokenId,trackee) >= _retiredBalances[tokenId][trackee], 
+                "CLM8::_update: the retired balance exceeds what has been reported in NET"
+            );
+        }
+        return total;
+    }
+    function _verifyTransferred(uint tokenId, address trackee, 
+        uint amountOld, uint amountNew) internal {
+        if(amountOld>0){
+            //adjust existing _transferredBalances for tokenTypeId 4
+            _transferredBalances[tokenId][trackee]
+                =_transferredBalances[tokenId][trackee].sub(amountOld);
+        }
+        if(amountNew>0){
+            _transferredBalances[tokenId][trackee]
+                =_transferredBalances[tokenId][trackee].add(amountNew);
+            require(
+                net.getTransferredBalances(tokenId,trackee) >= _transferredBalances[tokenId][trackee], 
+                "CLM8::_update: the transferred balance exceeds what has been reported in NET"
+            );
+        }
+    }
+
+    function audit(uint trackerId) 
+        public notAudited(trackerId) isAuditor(trackerId){
+        _trackerData[trackerId].auditor=msg.sender;   
+    }
+
+    function removeAudit(uint trackerId) public isAuditor(trackerId){
+        delete _trackerData[trackerId].auditor;
+    }
+    /**
+     * @dev msg.sender can volunteer themselves as registered tracker or admin
+     */
+    function registerTracker(address tracker) selfOrAdmin(tracker) external
+    {
+        _setupRole(REGISTERED_TRACKER, tracker);
+        emit RegisteredTracker(tracker);
+    }
+    /**
+     * @dev change trackee of trackerId
+     * @param trackerId - id of token tp be changed
+     */
+    function changeTrackee(uint trackerId, address trackee) external 
+        onlyAdmin registeredTracker(trackee) trackerTokenkExists(trackerId){
+        CarbonTrackerDetails storage trackerData = _trackerData[trackerId];
+        trackerData.trackee = trackee;
+        emit TrackeeChanged(trackerId,trackee);
+    }    
+    /**
+     * @dev approve auditor for trackee as msg.sender
+     * auditor - to be approved or removed
+     * approve - approve (true) or remove (false)
+     */
+    function approveAuditor(address auditor,bool approve) 
+        external notSender(auditor){
+        require(
+            net.isAuditor(auditor) || !approve,
+            "CLM8::approveAuditor: address is not a registered emissions auditor"
+        );
+        isAuditorApproved[auditor][msg.sender]=approve;
+        if(approve){
+            emit AuditorApproved(auditor,msg.sender);
+        }else{
+            emit AuditorRemoved(auditor,msg.sender);
+        }
+    }
+}

--- a/net-emissions-token-network/contracts/Governance/CarbonTracker.sol
+++ b/net-emissions-token-network/contracts/Governance/CarbonTracker.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 import "../NetEmissionsTokenNetwork.sol";
-import "@openzeppelin/contracts-upgradeable/math/SafeMathUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/math/SafeMathUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol";
 
 contract CarbonTracker is Initializable, ERC721Upgradeable, AccessControlUpgradeable {
@@ -154,6 +154,11 @@ contract CarbonTracker is Initializable, ERC721Upgradeable, AccessControlUpgrade
         require(arrayOne.length == arrrayTwo.length, 
             "CLM8::_equalLength: array lengths are not equal"); 
         _;
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view virtual 
+        override(ERC721Upgradeable,AccessControlUpgradeable) returns (bool) {
+        return interfaceId == type(IAccessControlUpgradeable).interfaceId || super.supportsInterface(interfaceId);
     }
     /**
      * @dev msg.sender is trackee or approved auditor of trackee

--- a/net-emissions-token-network/contracts/Governance/DAOToken.sol
+++ b/net-emissions-token-network/contracts/Governance/DAOToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -119,8 +119,8 @@ contract DAOToken {
      */
     function approve(address spender, uint rawAmount) external returns (bool) {
         uint96 amount;
-        if (rawAmount == uint(-1)) {
-            amount = uint96(-1);
+        if (rawAmount == type(uint).max) {
+            amount = type(uint96).max;
         } else {
             amount = safe96(rawAmount, "dCLM8::approve: amount exceeds 96 bits");
         }
@@ -172,7 +172,7 @@ contract DAOToken {
         uint96 spenderAllowance = allowances[src][spender];
         uint96 amount = safe96(rawAmount, "dCLM8::approve: amount exceeds 96 bits");
 
-        if (spender != src && spenderAllowance != uint96(-1)) {
+        if (spender != src && spenderAllowance != type(uint96).max) {
             uint96 newAllowance = sub96(spenderAllowance, amount, "dCLM8::transferFrom: transfer amount exceeds spender allowance");
             allowances[src][spender] = newAllowance;
 
@@ -361,7 +361,7 @@ contract DAOToken {
         return a - b;
     }
 
-    function getChainId() internal pure returns (uint) {
+    function getChainId() internal view returns (uint) {
         uint256 chainId;
         assembly { chainId := chainid() }
         return chainId;

--- a/net-emissions-token-network/contracts/Governance/Governor.sol
+++ b/net-emissions-token-network/contracts/Governance/Governor.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -704,7 +704,7 @@ contract Governor {
         }
     }
 
-    function getChainId() internal pure returns (uint) {
+    function getChainId() internal view returns (uint) {
         uint chainId;
         assembly { chainId := chainid() }
         return chainId;

--- a/net-emissions-token-network/contracts/Governance/Timelock.sol
+++ b/net-emissions-token-network/contracts/Governance/Timelock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 // SPDX-License-Identifier: BSD-3-Clause
 
 /* Copyright 2021 Compound Labs, Inc.
@@ -27,7 +27,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
 // Original work from Compound: https://github.com/compound-finance/compound-protocol/blob/master/contracts/Timelock.sol
 // Modified to work in the NetEmissionsTokenNetwork system
 
-import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 
 contract Timelock {
     using SafeMath for uint;

--- a/net-emissions-token-network/contracts/NetEmissionsTokenNetwork.sol
+++ b/net-emissions-token-network/contracts/NetEmissionsTokenNetwork.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
-import "@openzeppelin/contracts-upgradeable/math/SafeMathUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/math/SafeMathUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol";
-import "@openzeppelin/contracts-upgradeable/cryptography/ECDSAUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/cryptography/ECDSAUpgradeable.sol";
 contract NetEmissionsTokenNetwork is Initializable, ERC1155Upgradeable, AccessControlUpgradeable {
 
     using SafeMathUpgradeable for uint256;
@@ -246,6 +246,11 @@ contract NetEmissionsTokenNetwork is Initializable, ERC1155Upgradeable, AccessCo
      */
     function getNumOfUniqueTokens() public view returns (uint256) {
         return _numOfUniqueTokens.current();
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view virtual 
+        override(ERC1155Upgradeable,AccessControlUpgradeable) returns (bool) {
+        return interfaceId == type(IAccessControlUpgradeable).interfaceId || super.supportsInterface(interfaceId);
     }
 
     /**

--- a/net-emissions-token-network/contracts/NetEmissionsTokenNetworkV2.sol
+++ b/net-emissions-token-network/contracts/NetEmissionsTokenNetworkV2.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
-import "@openzeppelin/contracts-upgradeable/math/SafeMathUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/math/SafeMathUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 // V2 example file for testing upgrades
 // This is NOT up to date or a real upgrade of NetEmissionsTokenNetwork.sol
@@ -184,6 +184,10 @@ contract NetEmissionsTokenNetworkV2 is Initializable, ERC1155Upgradeable, Access
         return _numOfUniqueTokens.current();
     }
 
+    function supportsInterface(bytes4 interfaceId) public view virtual 
+        override(ERC1155Upgradeable,AccessControlUpgradeable) returns (bool) {
+        return interfaceId == type(IAccessControlUpgradeable).interfaceId || super.supportsInterface(interfaceId);
+    }
     /**
      * @dev hook to prevent transfers from non-admin account if limitedMode is on
      */

--- a/net-emissions-token-network/contracts/NetEmissionsTokenNetworkV2.sol
+++ b/net-emissions-token-network/contracts/NetEmissionsTokenNetworkV2.sol
@@ -70,6 +70,10 @@ contract NetEmissionsTokenNetworkV2 is Initializable, ERC1155Upgradeable, Access
     // Token metadata and retired balances
     mapping(uint256 => CarbonTokenDetails) private _tokenDetails;
     mapping(uint256 => mapping(address => uint256)) private _retiredBalances;
+    mapping(uint256 => mapping(address => uint256)) private _transferredBalances;
+
+    // Nonce for tokeTypeId 4 transfer from => to account
+    mapping(address => mapping(address => uint32)) private carbonTransferNonce;
 
     address private newTestVariable;
 
@@ -129,7 +133,7 @@ contract NetEmissionsTokenNetworkV2 is Initializable, ERC1155Upgradeable, Access
 
         require(
             isConsumer || isRecDealer || isCeoDealer || isAeDealer,
-            "CLM8::consumerOrDealer: msg.sender not a consumer or a dealer"
+            "CLM8::consumerOrDealer: sender not a consumer or a dealer"
         );
 
         _;

--- a/net-emissions-token-network/contracts/NetEmissionsTokenNetworkV3.sol
+++ b/net-emissions-token-network/contracts/NetEmissionsTokenNetworkV3.sol
@@ -8,7 +8,7 @@ import "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol
 import "@openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/cryptography/ECDSAUpgradeable.sol";
-contract NetEmissionsTokenNetwork is Initializable, ERC1155Upgradeable, AccessControlUpgradeable {
+contract NetEmissionsTokenNetwork3 is Initializable, ERC1155Upgradeable, AccessControlUpgradeable {
 
     using SafeMathUpgradeable for uint256;
     using CountersUpgradeable for CountersUpgradeable.Counter;
@@ -191,7 +191,7 @@ contract NetEmissionsTokenNetwork is Initializable, ERC1155Upgradeable, AccessCo
     function _consumerOrDealer(address entity) public view returns (bool) {
         // check for one role and return if true if true
         // before checking the next to minimze gas
-        if(hasRole(REGISTERED_DEALER, entity) ||
+        if(hasRole(REGISTERED_DEALER,entity) ||
            hasRole(REGISTERED_CONSUMER, entity) ||
            hasRole(REGISTERED_INDUSTRY, entity) 
         ) return true;

--- a/net-emissions-token-network/contracts/NetEmissionsTokenNetworkV3.sol
+++ b/net-emissions-token-network/contracts/NetEmissionsTokenNetworkV3.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
-import "@openzeppelin/contracts-upgradeable/math/SafeMathUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/math/SafeMathUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol";
-import "@openzeppelin/contracts-upgradeable/cryptography/ECDSAUpgradeable.sol";
-contract NetEmissionsTokenNetwork3 is Initializable, ERC1155Upgradeable, AccessControlUpgradeable {
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/cryptography/ECDSAUpgradeable.sol";
+contract NetEmissionsTokenNetworkV3 is Initializable, ERC1155Upgradeable, AccessControlUpgradeable {
 
     using SafeMathUpgradeable for uint256;
     using CountersUpgradeable for CountersUpgradeable.Counter;
@@ -191,7 +191,7 @@ contract NetEmissionsTokenNetwork3 is Initializable, ERC1155Upgradeable, AccessC
     function _consumerOrDealer(address entity) public view returns (bool) {
         // check for one role and return if true if true
         // before checking the next to minimze gas
-        if(hasRole(REGISTERED_DEALER,entity) ||
+        if(hasRole(REGISTERED_DEALER, entity) ||
            hasRole(REGISTERED_CONSUMER, entity) ||
            hasRole(REGISTERED_INDUSTRY, entity) 
         ) return true;
@@ -246,6 +246,11 @@ contract NetEmissionsTokenNetwork3 is Initializable, ERC1155Upgradeable, AccessC
      */
     function getNumOfUniqueTokens() public view returns (uint256) {
         return _numOfUniqueTokens.current();
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view virtual 
+        override(ERC1155Upgradeable,AccessControlUpgradeable) returns (bool) {
+        return interfaceId == type(IAccessControlUpgradeable).interfaceId || super.supportsInterface(interfaceId);
     }
 
     /**

--- a/net-emissions-token-network/deploy/net-emissions-token-network.js
+++ b/net-emissions-token-network/deploy/net-emissions-token-network.js
@@ -31,6 +31,22 @@ module.exports = async ({
   );
   console.log("Timelock address set so that the DAO has permission to issue tokens with issueOnBehalf().");
 
+
+  console.log(`Deploying CarbonTracker with account: ${deployer}`);
+
+  let carbonTracker = await deploy('CarbonTracker', {
+    from: deployer,
+    proxy: {
+      owner: deployer,
+      proxyContract: "OptimizedTransparentProxy",
+      methodName: 'initialize'
+    },
+    args: [ netEmissionsTokenNetwork.address, deployer, ],
+  });
+
+  console.log("CarbonTracker deployed to:", carbonTracker.address);
+
+
 };
 
 module.exports.tags = ['CLM8'];

--- a/net-emissions-token-network/docs/carbon-tracker.md
+++ b/net-emissions-token-network/docs/carbon-tracker.md
@@ -1,0 +1,43 @@
+# Carbon Tracker:
+
+## An NFT using ERC721Upgradeable template create carbon trackers
+- Each NFT is used to track the unique emission profile of a product/facility based on NETs
+- NETs in each NFTs can be linked to previous NFT connect emission profiles (embedded emissions)
+    - The IDs and amonts of NETs defined as inputs/outputs to the tracker .
+    - Inputs are defined as burnt tokens of Type 3,4 (audited emission token, industry emissions token) 
+    - There are two types of outputs:
+        1. carbon transfers (type 4 unburnt fuel/feedstock) 
+        2. audited emissions (type 3) issued incunjunction with a tracker Id
+    - to track transfers with token type 4:    
+        - trackerId: (map) input tokenId to a previous tracker id
+        - totalIn: (map) tokenId (type 4) to aggregate anount tracked in by other trackers
+    - totalAudited: total audited emissions (type 3) generated for this tracker (outputs)
+    - totalEmission: total emissions tracked here  
+- Unique audited emission certificates may be issued for each NFT:
+    - track embedded emission transfers (e.g. scope 2/3) for non-hydrocarbon fuel/feedstock product transfers
+    - auditedTrackerId maps audited emission token to trackerId
+- validation of retired/audited and transfered emission balances so that tracker entries don't conflit with NET.
+
+
+## A new token for registered industry
+
+TokenTypeId=4 for carbon Tokens issued by registered industry of the Net Emission Token (NET) Network. This supply side token and CarbonTracker contract enable shared emission inventories across organizations and  embedded emission tracking.
+Carbon tokens can only be transferred with the approval of the receiving party using the openzepplin ECDSAUpgradeable
+
+Additions/changes to the NetEmissionTokenNetwork contract:
+- Role REGISTERED_INDUSTRY: new industry actors, self assigned or admin elected
+- Role REGISTERED_INDUSTRY_DEALER: elected by admin as official Carbon Token industry dealers
+- Mapping `_transferredBalances` allows CarbonTracker to check the transferred balances of a tokenId by a given address. The address can not track more transfers than reported within NET. 
+- mapping `carbonTransferNonce`: 
+    - prevent processing of carbon token transfers (tokenTypeID=4) multiple times. 
+    - Used in getTransferHash (see below)
+    - Increment in _beforeTokenTransfer hook when approveCarbon require verifySignature (see below).
+- Modifier consumerOrDealer(address from,address to): modifer for filter for from and to addresses.
+    - from!=address(0): if not minting require sender to be consumerOrDealer
+    - to!=address(0): if not burning require receiver is consumerOrDealer  
+- function `_beforeTokenTransfer()`: saferansfer() hook
+    - Ensures that require is enforced for all safeTransferFrom (or Batch) calls. 
+    - Also applies to issue `super._mint` and retire `super._burn`.
+    - if condition tokenTypeId == 4, require receiverApproved()
+- `getTransferHash()`: create Hash of token transfer from,to,ids,amounts
+- `verifySignature()`: require address that signed getTransferHash() matches to address

--- a/net-emissions-token-network/hardhat.config.js
+++ b/net-emissions-token-network/hardhat.config.js
@@ -354,10 +354,17 @@ module.exports = {
             runs: 200
           }
         }
+      },
+      {
+        version: "0.8.3",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200
+          }
+        }
       }
     ]
-
-
   },
   gasReporter: {
     currency: 'USD',

--- a/net-emissions-token-network/hardhat.config.js
+++ b/net-emissions-token-network/hardhat.config.js
@@ -76,7 +76,7 @@ task("getProposalThreshold", "Return the proposal threshold (amount of dCLM8 req
 task("setTestAccountRoles", "Set default account roles for testing")
   .addParam("contract", "The CLM8 contract")
   .setAction(async taskArgs => {
-    const {dealer1, dealer2, dealer3, consumer1, consumer2} = await getNamedAccounts();
+    const {dealer1, dealer2, dealer3, consumer1, consumer2, industry1, industry2} = await getNamedAccounts();
 
     const [admin] = await ethers.getSigners();
     const NetEmissionsTokenNetwork = await hre.ethers.getContractFactory("NetEmissionsTokenNetwork");
@@ -89,7 +89,13 @@ task("setTestAccountRoles", "Set default account roles for testing")
     await contract.connect(admin).registerDealer(dealer3, 2); // offsets dealer
     console.log("Account " + dealer3 + " is now an offsets  dealer");
 
-    await contract.connect(admin).registerConsumer(consumer1);
+    await contract.connect(admin).registerDealer(industry1,4);
+    console.log("Account " + industry1 + " is now an industry")
+    // self registered industry dealer
+    await contract.connect(await ethers.getSigner(industry1)).registerIndustry(industry2);
+    console.log("Account " + industry2 + " is now an industry")
+
+    await contract.connect(await ethers.getSigner(industry1)).registerConsumer(consumer1);
     console.log("Account " + consumer1 + " is now a consumer");
     await contract.connect(admin).registerConsumer(consumer2);
     console.log("Account " + consumer2 + " is now a consumer");
@@ -332,6 +338,8 @@ module.exports = {
     dealer4: { default: 4 },
     consumer1: { default: 19 },
     consumer2: { default: 18 },
+    industry1: { default: 15 },
+    industry2: { default: 16 },
     unregistered: { default: 7 }
   },
 

--- a/net-emissions-token-network/package-lock.json
+++ b/net-emissions-token-network/package-lock.json
@@ -10,8 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "@eth-optimism/plugins": "0.0.16",
-        "@openzeppelin/contracts": "^3.3.0",
-        "@openzeppelin/contracts-upgradeable": "^3.4.1"
+        "@openzeppelin/contracts": "^4.4.1",
+        "@openzeppelin/contracts-upgradeable": "^4.4.1"
       },
       "devDependencies": {
         "@nomiclabs/hardhat-ethers": "^2.0.1",
@@ -284,6 +284,11 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/@eth-optimism/contracts/node_modules/@openzeppelin/contracts": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.4.2.tgz",
+      "integrity": "sha512-z0zMCjyhhp4y7XKAcDAi3Vgms4T2PstwBdahiO0+9NaGICQKjynK3wduSRplTgk4LXmoO1yfDGO5RbjKYxtuxA=="
     },
     "node_modules/@eth-optimism/contracts/node_modules/ethers": {
       "version": "5.0.0",
@@ -1819,14 +1824,14 @@
       "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
     },
     "node_modules/@openzeppelin/contracts": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.3.0.tgz",
-      "integrity": "sha512-AemZEsQYtUp1WRkcmZm1div5ORfTpLquLaziCIrSagjxyKdmObxuaY1yjQ5SHFMctR8rLwp706NXTbiIRJg7pw=="
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.4.1.tgz",
+      "integrity": "sha512-o+pHCf/yMLSlV5MkDQEzEQL402i6SoRnktru+0rdSxVEFZcTzzGhZCAtZjUFyKGazMSv1TilzMg+RbED1N8XHQ=="
     },
     "node_modules/@openzeppelin/contracts-upgradeable": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-3.4.1.tgz",
-      "integrity": "sha512-wBGlUzEkOxcj/ghtcF2yKc8ZYh+PTUtm1mK38zoENulJ6aplij7eH8quo3lMugfzPJy+V6V5qI8QhdQmCn7hkQ=="
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.4.1.tgz",
+      "integrity": "sha512-84dUN+TBY42D52BzUc4RHxU4KORs8Ys7dj3nH0WX1QKtlS6rrN45gL+sxaotkPdCqFLVLPyj+kd8GfJ4puxVjA=="
     },
     "node_modules/@openzeppelin/hardhat-upgrades": {
       "version": "1.6.0",
@@ -23014,6 +23019,11 @@
             "tmp": "0.0.33"
           }
         },
+        "@openzeppelin/contracts": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.4.2.tgz",
+          "integrity": "sha512-z0zMCjyhhp4y7XKAcDAi3Vgms4T2PstwBdahiO0+9NaGICQKjynK3wduSRplTgk4LXmoO1yfDGO5RbjKYxtuxA=="
+        },
         "ethers": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.0.tgz",
@@ -24192,14 +24202,14 @@
       }
     },
     "@openzeppelin/contracts": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.3.0.tgz",
-      "integrity": "sha512-AemZEsQYtUp1WRkcmZm1div5ORfTpLquLaziCIrSagjxyKdmObxuaY1yjQ5SHFMctR8rLwp706NXTbiIRJg7pw=="
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.4.1.tgz",
+      "integrity": "sha512-o+pHCf/yMLSlV5MkDQEzEQL402i6SoRnktru+0rdSxVEFZcTzzGhZCAtZjUFyKGazMSv1TilzMg+RbED1N8XHQ=="
     },
     "@openzeppelin/contracts-upgradeable": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-3.4.1.tgz",
-      "integrity": "sha512-wBGlUzEkOxcj/ghtcF2yKc8ZYh+PTUtm1mK38zoENulJ6aplij7eH8quo3lMugfzPJy+V6V5qI8QhdQmCn7hkQ=="
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.4.1.tgz",
+      "integrity": "sha512-84dUN+TBY42D52BzUc4RHxU4KORs8Ys7dj3nH0WX1QKtlS6rrN45gL+sxaotkPdCqFLVLPyj+kd8GfJ4puxVjA=="
     },
     "@openzeppelin/hardhat-upgrades": {
       "version": "1.6.0",

--- a/net-emissions-token-network/package-lock.json
+++ b/net-emissions-token-network/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "net-emissions-token-network",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/net-emissions-token-network/package.json
+++ b/net-emissions-token-network/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@eth-optimism/plugins": "0.0.16",
-    "@openzeppelin/contracts": "^3.3.0",
-    "@openzeppelin/contracts-upgradeable": "^3.4.1"
+    "@openzeppelin/contracts": "^4.4.1",
+    "@openzeppelin/contracts-upgradeable": "^4.4.1"
   }
 }

--- a/net-emissions-token-network/test/common.js
+++ b/net-emissions-token-network/test/common.js
@@ -3,7 +3,7 @@ const { expect } = require("chai");
 const { upgrades } = require("hardhat");
 const { ethers } = require("./ethers-provider");
 
-exports.allTokenTypeId = [1, 2, 3];
+exports.allTokenTypeId = [1, 2, 3, 4];
 exports.quantity = 10;
 exports.transferAmount = 5;
 exports.retireAmount = 3;

--- a/net-emissions-token-network/test/token-network-unit-tests.js
+++ b/net-emissions-token-network/test/token-network-unit-tests.js
@@ -43,7 +43,7 @@ describe("Net Emissions Token Network - Unit tests", function() {
         .connect(await ethers.getSigner(dealer1))
         .issue(
           consumer1,
-          "4",
+          "5",
           quantity,
           fromDate,
           thruDate,
@@ -116,50 +116,52 @@ describe("Net Emissions Token Network - Unit tests", function() {
 
   it("should return the correct roles after owner assigns them", async function() {
 
-    const { deployer, dealer1, dealer2, dealer3, consumer1, unregistered } = await getNamedAccounts();
+    const { deployer, dealer1, dealer2, dealer3, industry1, consumer1, unregistered } = await getNamedAccounts();
 
     // register roles
     let registerRecdealer = await contract.registerDealer(dealer1, allTokenTypeId[0]);
     let registerCeodealer = await contract.registerDealer(dealer2, allTokenTypeId[1]);
     let registerAedealer = await contract.registerDealer(dealer3, allTokenTypeId[2]);
+    let registerIndustry = await contract.registerDealer(industry1, allTokenTypeId[3]);
     let registerconsumer = await contract.registerConsumer(consumer1);
     expect(registerRecdealer);
     expect(registerCeodealer);
     expect(registerAedealer);
+    expect(registerIndustry);
     expect(registerconsumer);
 
     // @TODO: Remove owner role from dealers
     await contract
       .getRoles(deployer)
-      .then((response) => expect(response).to.deep.equal([true, true, true, true, false]));
+      .then((response) => expect(response).to.deep.equal([true, true, true, true, true, false]));
     await contract
       .getRoles(dealer1)
-      .then((response) => expect(response).to.deep.equal([false, true, false, false, false]));
+      .then((response) => expect(response).to.deep.equal([false, true, false, false, false, false]));
     await contract
       .getRoles(dealer2)
-      .then((response) => expect(response).to.deep.equal([false, false, true, false, false]));
+      .then((response) => expect(response).to.deep.equal([false, false, true, false, false, false]));
     await contract
       .getRoles(dealer3)
-      .then((response) => expect(response).to.deep.equal([false, false, false, true, false]));
+      .then((response) => expect(response).to.deep.equal([false, false, false, true, false, false]));
     await contract
       .getRoles(consumer1)
-      .then((response) => expect(response).to.deep.equal([false, false, false, false, true]));
+      .then((response) => expect(response).to.deep.equal([false, false, false, false, false, true]));
     await contract
       .getRoles(unregistered)
-      .then((response) => expect(response).to.deep.equal([false, false, false, false, false]));
+      .then((response) => expect(response).to.deep.equal([false, false, false, false, false, false]));
 
     // check assigning another dealer role to recDealer
     let registerRecdealerTwo = await contract.registerDealer(dealer1, allTokenTypeId[1]);
     expect(registerRecdealerTwo);
     await contract
       .getRoles(dealer1)
-      .then((response) => expect(response).to.deep.equal([false, true, true, false, false]));
+      .then((response) => expect(response).to.deep.equal([false, true, true, false, false, false]));
 
     // check unregistering that role from recDealer
     await contract.unregisterDealer(dealer1, allTokenTypeId[1]);
     await contract
       .getRoles(dealer1)
-      .then((response) => expect(response).to.deep.equal([false, true, false, false, false]));
+      .then((response) => expect(response).to.deep.equal([false, true, false, false, false, false]));
 
     // check if recDealer is dealer
     await contract
@@ -543,7 +545,7 @@ describe("Net Emissions Token Network - Unit tests", function() {
       error = err.toString();
     }
     expect(error).to.equal(
-      "Error: VM Exception while processing transaction: revert CLM8::consumerOrDealer: msg.sender not a consumer or a dealer"
+      "Error: VM Exception while processing transaction: revert CLM8::consumerOrDealer: sender not a consumer or a dealer"
     );
 
     // retire more than available balance
@@ -633,7 +635,7 @@ describe("Net Emissions Token Network - Unit tests", function() {
       error = err.toString();
     }
     expect(error).to.equal(
-      "Error: VM Exception while processing transaction: revert CLM8::transfer: Recipient must be consumer or dealer"
+      "Error: VM Exception while processing transaction: revert CLM8::consumerOrDealer: recipient must be consumer, dealer or industry"
     );
 
     // try to transfer to self
@@ -644,7 +646,7 @@ describe("Net Emissions Token Network - Unit tests", function() {
       error = err.toString();
     }
     expect(error).to.equal(
-      "Error: VM Exception while processing transaction: revert CLM8::transfer: sender and receiver cannot be the same"
+      "Error: VM Exception while processing transaction: revert CLM8::_beforeTokenTransfer: sender and receiver cannot be the same"
     );
 
   });

--- a/net-emissions-token-network/test/tracker-integration-tests.js
+++ b/net-emissions-token-network/test/tracker-integration-tests.js
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: Apache-2.0
+const { expect } = require("chai");
+const {
+  allTokenTypeId,
+  quantity,
+  retireAmount,
+  transferAmount,
+  fromDate,
+  thruDate,
+  automaticRetireDate,
+  metadata,
+  manifest,
+  description
+} = require("./common.js");
+const { ethers } = require("./ethers-provider");
+
+describe("Carbon Tracker - Integration tests", function() {
+
+  let contract;
+  beforeEach(async () => {
+    await deployments.fixture();
+    contract = await ethers.getContract('NetEmissionsTokenNetwork');
+    contractT = await ethers.getContract('CarbonTracker');
+  });
+
+  it("should issue a Carbon Token", async function() {
+
+    const { dealer1, deployer, industry1, industry2 } = await getNamedAccounts();
+
+    // register Industry (as admin REGISTERED_DEALER)
+    let registerDealerInd = await contract.registerDealer(industry1, allTokenTypeId[3]);
+    expect(registerDealerInd);
+    // industry1 to register industry2 (not admin authorized REGISTERED_DEALER )
+    let registerIndustryTwo = await contract.connect(await ethers.getSigner(industry1)).registerIndustry(industry2);
+    expect(registerIndustryTwo);
+    // register emission auditor dealer to issue carbon tokens
+    let registerDealerAea = await contract.registerDealer(dealer1, allTokenTypeId[2]);
+    expect(registerDealerAea);
+
+    // register Industry as tracker(volunteer)
+    let registerTracker = await contractT.connect(await ethers.getSigner(industry1)).registerTracker(industry1);
+    expect(registerTracker);
+
+    try {
+      await contractT
+        .connect(await ethers.getSigner(industry1))
+        .registerTracker(industry2);
+    } catch (err) {
+      expect(err.toString()).to.equal("Error: VM Exception while processing transaction: revert CLM8::selfOrAdmin: msg.sender does not own this address or is not an admin");
+    }
+
+    // register Industry as tracker (admin assigned)
+    let registerTrackerIndTwo = await contractT.connect(await ethers.getSigner(deployer)).registerTracker(industry2);
+    expect(registerTrackerIndTwo);
+
+    ////////////////////
+    let issue = await contract
+      .connect(await ethers.getSigner(industry1))
+      .issue(
+        industry1,
+        allTokenTypeId[3],
+        quantity,
+        fromDate,
+        thruDate,
+        automaticRetireDate,
+        metadata,
+        manifest,
+        description
+      );
+    // Check to be certain mint did not return errors
+    expect(issue);
+
+    // Get ID of token just issued
+    let transactionReceipt = await issue.wait(0);
+    let issueEvent = transactionReceipt.events.pop();
+    let tokenId = issueEvent.args[2].toNumber();
+    expect(tokenId).to.equal(1);
+
+
+    // retire part of the balance
+    let retire = await contract.connect(await ethers.getSigner(industry1)).retire(tokenId, retireAmount);
+    let retireReceipt = await retire.wait(0);
+    let retireEvent = retireReceipt.events.pop();
+    let retireIdOne = retireEvent.args[1].toNumber();
+    let retireAmountOne = retireEvent.args[2].toNumber();
+    let txHashRetireOne = ethers.utils.arrayify(retireEvent.transactionHash);
+
+    // verify transfer to industry2 with approval signature.
+    let msg = await contract.getTransferHash(industry1, industry2, [tokenId], [transferAmount]);
+    msg = ethers.utils.arrayify(msg)
+    let signer = await ethers.getSigner(industry2);
+    let signature = await signer.signMessage(msg);
+
+    let transfer = await contract
+      .connect(await ethers.getSigner(industry1))
+      .safeTransferFrom(industry1, industry2, tokenId, transferAmount, signature);
+    expect(transfer);   
+
+    let transferReceipt = await transfer.wait(0);
+    let transferEvent = transferReceipt.events.pop();
+    let transferIdOne = transferEvent.args[3].toNumber();
+    let transferAmountOne = transferEvent.args[4].toNumber();
+    expect(tokenId).to.equal(1);
+    let txHashTransferOne = ethers.utils.arrayify(transferEvent.transactionHash);
+
+    // verify balances after retiring.  The available to transfer balance should be reduced and retired balance is increased
+    let expectedTotalAvailableAfterRetireAndTransfer = (quantity - retireAmountOne - transferAmountOne).toString();
+    let expectedTotalRetireAfterRetire = retireAmountOne.toString();
+    let afterRetireAndTransferBalance = await contract
+      .getAvailableAndRetired(industry1, tokenId)
+      .then((response) =>
+        expect(response.toString()).to.equal(`${expectedTotalAvailableAfterRetireAndTransfer},${expectedTotalRetireAfterRetire}`)
+      );
+
+
+    ////////////////////
+    let issueTwo = await contract
+      .connect(await ethers.getSigner(industry1))
+      .issue(
+        industry1,
+        allTokenTypeId[3],
+        quantity,
+        fromDate,
+        thruDate,
+        automaticRetireDate,
+        metadata,
+        manifest,
+        description
+      );
+    // Check to be certain mint did not return errors
+    expect(issueTwo);
+
+    // Get ID of token just issued
+    transactionReceipt = await issueTwo.wait(0);
+    issueEvent = transactionReceipt.events.pop();
+    let tokenIdTwo = issueEvent.args[2].toNumber();
+    expect(tokenIdTwo).to.equal(2);
+
+    // retire part of the balance
+    retire = await contract.connect(await ethers.getSigner(industry1)).retire(tokenIdTwo, retireAmount);
+    retireReceipt = await retire.wait(0);
+    retireEvent = retireReceipt.events.pop();
+    let retireIdTwo = retireEvent.args[1].toNumber();
+    let retireAmountTwo = retireEvent.args[2].toNumber();
+    expect(retireAmountTwo).to.equal(retireAmount);
+    let txHashRetireTwo = ethers.utils.arrayify(retireEvent.transactionHash);
+
+    // verify transfer to industry2 with approval signature.
+    msg = await contract.getTransferHash(industry1, industry2, [tokenIdTwo], [transferAmount]);
+    msg = ethers.utils.arrayify(msg)
+    signer = await ethers.getSigner(industry2);
+    signature = await signer.signMessage(msg);
+
+    transfer = await contract
+      .connect(await ethers.getSigner(industry1))
+      .safeTransferFrom(industry1, industry2, tokenIdTwo, transferAmount, signature);
+    expect(transfer);
+
+    transferReceipt = await transfer.wait(0);
+    transferEvent = transferReceipt.events.pop();
+    let transferIdTwo = transferEvent.args[3].toNumber();
+    let transferAmountTwo = transferEvent.args[4].toNumber();
+    let txHashTransferTwo = ethers.utils.arrayify(transferEvent.transactionHash);
+
+    ////////////////////
+    let issueThree = await contract
+      .connect(await ethers.getSigner(industry2))
+      .issue(
+        industry2,
+        allTokenTypeId[3],
+        quantity,
+        fromDate,
+        thruDate,
+        automaticRetireDate,
+        metadata,
+        manifest,
+        description
+      );
+    // Check to be certain mint did not return errors
+    expect(issueThree);
+
+    // Get ID of token just issued
+    transactionReceipt = await issueThree.wait(0);
+    issueEvent = transactionReceipt.events.pop();
+    let tokenIdThree = issueEvent.args[2].toNumber();
+    expect(tokenIdThree).to.equal(3);
+
+    // retire part of the balance
+    retire = await contract.connect(await ethers.getSigner(industry2)).retire(tokenIdThree, retireAmount);
+    retireReceipt = await retire.wait(0);
+    retireEvent = retireReceipt.events.pop();
+    let retireIdThree = retireEvent.args[1].toNumber();
+    let retireAmountThree = retireEvent.args[2].toNumber();
+    expect(retireIdThree).to.equal(3);
+    let txHashRetireThree = ethers.utils.arrayify(retireEvent.transactionHash);
+
+    // verify transfer to industry2 with approval signature.
+    msg = await contract.getTransferHash(industry2, industry1, [tokenIdThree], [transferAmount]);
+    msg = ethers.utils.arrayify(msg)
+    signer = await ethers.getSigner(industry1);
+    signature = await signer.signMessage(msg);
+
+    transfer = await contract
+      .connect(await ethers.getSigner(industry2))
+      .safeTransferFrom(industry2, industry1, tokenIdThree, transferAmount, signature);
+    expect(transfer);
+    
+
+    transferReceipt = await transfer.wait(0);
+    transferEvent = transferReceipt.events.pop();
+    let transferIdThree = transferEvent.args[3].toNumber();
+    let transferAmountThree = transferEvent.args[4].toNumber();
+    expect(transferAmountThree).to.equal(transferAmount);
+    let txHashTransferThree = ethers.utils.arrayify(transferEvent.transactionHash);
+
+    ////////////////////
+    let issueAe = await contract
+      .connect(await ethers.getSigner(dealer1))
+      .issue(
+        industry1,
+        allTokenTypeId[2],
+        quantity,
+        fromDate,
+        thruDate,
+        automaticRetireDate,
+        metadata,
+        manifest,
+        description
+      );
+    // Check to be certain mint did not return errors
+    expect(issueAe);
+    let issueAeReceipt = await issueAe.wait(0);
+    let issueAeEvent = issueAeReceipt.events.pop();
+    let issueAeId = issueAeEvent.args[2].toNumber();;
+    let issueAeAmount = issueAeEvent.args[1].toNumber();;
+    expect(issueAeId).to.equal(4);
+    let txHashIssueAe = ethers.utils.arrayify(issueAeEvent.transactionHash);
+
+    let issueTracker = await contractT
+      .connect(await ethers.getSigner(industry1))
+      .track(industry1, 
+      [retireIdOne,retireIdTwo],
+      [retireAmountOne,retireAmountTwo],
+      [transferIdOne, transferIdTwo],
+      [transferAmountOne, transferAmountTwo],
+      []
+    )
+    expect(issueTracker);
+    let trackerReceipt = await issueTracker.wait(0);
+    let trackerEvent = trackerReceipt.events.pop();
+    console.log(trackerEvent);
+  });
+});

--- a/utility-emissions-channel/typescript_app/src/blockchain-gateway/netEmissionsTokenNetwork.ts
+++ b/utility-emissions-channel/typescript_app/src/blockchain-gateway/netEmissionsTokenNetwork.ts
@@ -39,6 +39,29 @@ export default class EthNetEmissionsTokenGateway implements IEthNetEmissionsToke
         this.EventTokenCreatedInput = tokenCreatedABI.inputs;
     }
 
+    async registerConsumer(
+        caller: IEthTxCaller,
+        input: { address: string },
+    ): Promise<{ address: string }> {
+        const fnTag = `${this.className}.issue()`;
+        ledgerLogger.debug(`${fnTag} getting signer for client`);
+        const signer = await this.opts.signer.ethereum(caller);
+        ledgerLogger.debug(`${fnTag} calling issue method input = %o`, input);
+        try {
+            await this.opts.ethClient.invokeContract({
+                contractName: this.contractName,
+                signingCredential: signer,
+                invocationType: EthContractInvocationType.Send,
+                methodName: 'registerConsumer',
+                params: [input.address],
+                keychainId: this.opts.contractStoreKeychain,
+            });
+        } catch (error) {
+            throw new ClientError(`${fnTag} failed to invoke issue method : ${error.message}`, 409);
+        }
+        return { address: input.address };
+    }
+
     async issue(
         caller: IEthTxCaller,
         input: IEthNetEmissionsTokenIssueInput,

--- a/utility-emissions-channel/typescript_app/tests/blockchain-gateway/netEmissionsTokenNetwork.test.ts
+++ b/utility-emissions-channel/typescript_app/tests/blockchain-gateway/netEmissionsTokenNetwork.test.ts
@@ -33,6 +33,13 @@ describe('EthNetEmissionsTokenGateway', () => {
             address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
             private: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
         };
+
+        it('should register consumer', async () => {
+            await gateway.registerConsumer(caller, {
+                address: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+            });
+        });
+
         it('should issue emission token', async () => {
             const input: IEthNetEmissionsTokenIssueInput = {
                 addressToIssue: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',


### PR DESCRIPTION
    This commit address a low severity vulnerability in openzeppelin contracts 3.3.0/3.4.1. Should respond to [PR 374](https://github.com/hyperledger-labs/blockchain-carbon-accounting/pull/374) and [PR 375](https://github.com/hyperledger-labs/blockchain-carbon-accounting/pull/375) 
    Requires upgrading to solidity ^0.8.0 - now using compiler version 0.8.3:
        - Derived contract must override function "supportsInterface" (see new overrides in derived contracts)
        - Require changing getChainId() (DAOToken/Governor contracts) from pure to view
        - uint(-1) changec to type(uint).max