### PR TITLE
feat(OrbitDB): add OrbitDB service to use it outside of chaincode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,7 +81,9 @@ utility-emissions-channel/docker-compose-setup/*.tar.gz
 utility-emissions-channel/docker-compose-setup/log.txt
 utility-emissions-channel/docker-compose-setup/node_modules
 utility-emissions-channel/docker-compose-setup/data/node_modules
+utility-emissions-channel/docker-compose-setup/data/dist
 utility-emissions-channel/docker-compose-setup/data/orbitdb
+utility-emissions-channel/docker-compose-setup/data/src/orbitdb
 utility-emissions-channel/docker-compose-setup/*.zip
 utility-emissions-channel/docker-compose-setup/*.xlsx
 utility-emissions-channel/docker-compose-setup/*.csv

--- a/utility-emissions-channel/docker-compose-setup/data/package.json
+++ b/utility-emissions-channel/docker-compose-setup/data/package.json
@@ -21,7 +21,8 @@
     },
     "devDependencies": {
         "@types/cli-progress": "^3.9.2",
-        "@types/node": "^17.0.10",
+        "@types/node": "^17.0.13",
+        "@types/orbit-db": "https://github.com/orbitdb/orbit-db-types.git",
         "@types/yargs": "^17.0.8",
         "@typescript-eslint/eslint-plugin": "^5.10.1",
         "@typescript-eslint/parser": "^5.10.1",

--- a/utility-emissions-channel/docker-compose-setup/data/src/getData.ts
+++ b/utility-emissions-channel/docker-compose-setup/data/src/getData.ts
@@ -1,35 +1,8 @@
-import { create } from 'ipfs-http-client';
-import * as OrbitDB from 'orbit-db';
-const DB_NAME = 'org.hyperledger.blockchain-carbon-accounting';
-let db;
-
-// const UTILITY_EMISSIONS_FACTOR_CLASS_IDENTIFER =
-//     'org.hyperledger.blockchain-carbon-accounting.utilityemissionsfactoritem';
-// const UTILITY_LOOKUP_ITEM_CLASS_IDENTIFIER =
-//     'org.hyperledger.blockchain-carbon-accounting.utilitylookuplist';
+import { OrbitDBService } from './orbitDbService';
 
 (async () => {
-    const ipfs = await create();
-    const orbitdb = await OrbitDB.createInstance(ipfs);
-    const dbOptions = {
-        // Give write access to the creator of the database
-        accessController: {
-            type: 'orbitdb', //OrbitDBAccessController
-            write: [orbitdb.identity.id],
-        },
-        indexBy: 'uuid',
-    };
-
-    db = await orbitdb.docstore(DB_NAME, dbOptions);
-    await db.load();
-    console.log(`OrbitDB address: ${db.address.toString()}`);
-
-    // Listen for updates from peers
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    db.events.on('replicated', (_) => {
-        console.log(db.iterator({ limit: -1 }).collect());
-    });
-
-    console.log(await db.get(''));
-    return;
+    await OrbitDBService.init();
+    const db = new OrbitDBService();
+    console.log(await db.getUtilityEmissionsFactorsByDivision('ASCC', 'NERC_REGION'));
+    process.exit(0);
 })();

--- a/utility-emissions-channel/docker-compose-setup/data/src/orbitDbService.ts
+++ b/utility-emissions-channel/docker-compose-setup/data/src/orbitDbService.ts
@@ -1,0 +1,185 @@
+import { create } from 'ipfs-http-client';
+import OrbitDB from 'orbit-db';
+import type DocumentStore from 'orbit-db-docstore';
+
+const DB_NAME = 'org.hyperledger.blockchain-carbon-accounting';
+const UTILITY_LOOKUP_ITEM_CLASS_IDENTIFIER =
+    'org.hyperledger.blockchain-carbon-accounting.utilitylookuplist';
+const UTILITY_EMISSIONS_FACTOR_CLASS_IDENTIFER =
+    'org.hyperledger.blockchain-carbon-accounting.utilityemissionsfactoritem';
+
+interface DivisionsInterface {
+    division_type: string;
+    division_id: string;
+}
+
+export interface UtilityLookupItemInterface {
+    class?: string;
+    key?: string;
+    uuid: string;
+    year?: string;
+    utility_number?: string;
+    utility_name?: string;
+    country?: string;
+    state_province?: string;
+    divisions?: DivisionsInterface;
+}
+
+export interface UtilityEmissionsFactorInterface {
+    class?: string;
+    key?: string;
+    uuid: string;
+    year?: string;
+    country?: string;
+    division_type?: string;
+    division_id?: string;
+    division_name?: string;
+    net_generation?: string;
+    net_generation_uom?: string;
+    co2_equivalent_emissions?: string;
+    co2_equivalent_emissions_uom?: string;
+    source?: string;
+    non_renewables?: string;
+    renewables?: string;
+    percent_of_renewables?: string;
+}
+
+export const getYearFromDate = (date: string): number => {
+    const time = new Date(date);
+    if (!time.getFullYear()) {
+        throw new Error(`${date} date format not supported`);
+    }
+    return time.getFullYear();
+};
+
+export class OrbitDBService {
+    private static _db: DocumentStore<UtilityLookupItemInterface | UtilityEmissionsFactorInterface>;
+
+    public static init = async (): Promise<void> => {
+        const ipfs = create();
+
+        const orbitdb = await OrbitDB.createInstance(ipfs as any);
+        const dbOptions = {
+            // Give write access to the creator of the database
+            accessController: {
+                type: 'orbitdb',
+                write: [orbitdb.id],
+            },
+            indexBy: 'uuid',
+        };
+
+        const db = await orbitdb.docstore<
+            UtilityLookupItemInterface | UtilityEmissionsFactorInterface
+        >(DB_NAME, dbOptions);
+
+        await db.load();
+
+        OrbitDBService._db = db as DocumentStore<
+            UtilityLookupItemInterface | UtilityEmissionsFactorInterface
+        >;
+        console.log(`OrbitDB address: ${db.address.toString()}`);
+    };
+
+    public getUtilityLookupItem = (uuid: string): UtilityLookupItemInterface => {
+        return OrbitDBService._db.get(uuid)[0];
+    };
+
+    public getAllUtilityLookupItems = (): UtilityLookupItemInterface[] => {
+        return OrbitDBService._db.query(
+            (doc: UtilityLookupItemInterface) => doc.class == UTILITY_LOOKUP_ITEM_CLASS_IDENTIFIER,
+        ) as UtilityLookupItemInterface[];
+    };
+
+    public updateUtilityLookupItem = (item: UtilityLookupItemInterface): Promise<string> => {
+        return OrbitDBService._db.put(item);
+    };
+
+    public getUtilityEmissionsFactor = (uuid: string): UtilityEmissionsFactorInterface => {
+        return OrbitDBService._db.get(uuid)[0];
+    };
+
+    public updateUtilityEmissionsFactor = (
+        factor: UtilityEmissionsFactorInterface,
+    ): Promise<string> => {
+        return OrbitDBService._db.put(factor);
+    };
+
+    public getUtilityEmissionsFactorsByDivision(
+        divisionID: string,
+        divisionType: string,
+        year?: number,
+    ): UtilityEmissionsFactorInterface[] {
+        const maxYearLookup = 5; // if current year not found, try each preceding year up to this many times
+        let retryCount = 0;
+        let results: UtilityEmissionsFactorInterface[] = [];
+        while (results.length === 0 && retryCount <= maxYearLookup) {
+            if (year !== undefined) {
+                results = OrbitDBService._db.query((doc: UtilityEmissionsFactorInterface) => {
+                    const isEmissionsFactor = doc.class == UTILITY_EMISSIONS_FACTOR_CLASS_IDENTIFER;
+                    const hasDivisionId = doc.division_id == divisionID;
+                    const hasDivisionType = doc.division_type == divisionType;
+                    const isOfQueriedYear = doc.year == (year + retryCount * -1).toString();
+                    return isEmissionsFactor && hasDivisionId && hasDivisionType && isOfQueriedYear;
+                });
+            } else {
+                results = OrbitDBService._db.query((doc: UtilityEmissionsFactorInterface) => {
+                    const isEmissionsFactor = doc.class == UTILITY_EMISSIONS_FACTOR_CLASS_IDENTIFER;
+                    const hasDivisionId = doc.division_id == divisionID;
+                    const hasDivisionType = doc.division_type == divisionType;
+                    return isEmissionsFactor && hasDivisionId && hasDivisionType;
+                });
+            }
+            retryCount++;
+        }
+        if (results.length === 0) {
+            throw new Error('failed to get Utility Emissions Factors By division');
+        }
+        return results;
+    }
+
+    // used by recordEmissions
+    getEmissionsFactorByLookupItem(
+        lookup: UtilityLookupItemInterface,
+        thruDate: string,
+    ): UtilityEmissionsFactorInterface {
+        const hasStateData = lookup.state_province !== '';
+        const isNercRegion = lookup.divisions.division_type.toLowerCase() === 'nerc_region';
+        const isNonUSCountry =
+            lookup.divisions.division_type.toLowerCase() === 'country' &&
+            lookup.divisions.division_id.toLowerCase() !== 'usa';
+        let divisionID: string;
+        let divisionType: string;
+        let year: number;
+        if (hasStateData) {
+            divisionID = lookup.state_province;
+            divisionType = 'STATE';
+        } else if (isNercRegion) {
+            divisionID = lookup.divisions.division_id;
+            divisionType = lookup.divisions.division_type;
+        } else if (isNonUSCountry) {
+            divisionID = lookup.divisions.division_id;
+            divisionType = 'Country';
+        } else {
+            divisionID = 'USA';
+            divisionType = 'Country';
+        }
+
+        try {
+            year = getYearFromDate(thruDate);
+        } catch (error) {
+            console.error('could not fetch year');
+            console.error(error);
+        }
+
+        console.log('fetching utilityFactors');
+        const utilityFactors = this.getUtilityEmissionsFactorsByDivision(
+            divisionID,
+            divisionType,
+            year,
+        );
+        if (utilityFactors.length === 0) {
+            throw new Error('No utility emissions factor found for given query');
+        }
+        return utilityFactors[0];
+    }
+}

--- a/utility-emissions-channel/docker-compose-setup/data/yarn.lock
+++ b/utility-emissions-channel/docker-compose-setup/data/yarn.lock
@@ -518,12 +518,35 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
   integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
 
+"@types/bn.js@*":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-5.1.0.tgz#32c5d271503a12653c62cf4d2b45e6eab8cebc68"
+  integrity sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/cli-progress@^3.9.2":
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/@types/cli-progress/-/cli-progress-3.9.2.tgz#6ca355f96268af39bee9f9307f0ac96145639c26"
   integrity sha512-VO5/X5Ij+oVgEVjg5u0IXVe3JQSKJX+Ev8C5x+0hPy0AuWyW+bF8tbajR7cPFnDGhs7pidztcac+ccrDtk5teA==
   dependencies:
     "@types/node" "*"
+
+"@types/elliptic@^6.4.6":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@types/elliptic/-/elliptic-6.4.14.tgz#7bbaad60567a588c1f08b10893453e6b9b4de48e"
+  integrity sha512-z4OBcDAU0GVwDTuwJzQCiL6188QvZMkvoERgcVjq0/mPM8jCfdwZ3x5zQEVoL9WCAru3aG5wl3Z5Ww5wBWn7ZQ==
+  dependencies:
+    "@types/bn.js" "*"
+
+"@types/events@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
+  integrity sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==
+
+"@types/ipfs@git+https://github.com/lukas2005/types-ipfs.git":
+  version "0.23.6"
+  resolved "git+https://github.com/lukas2005/types-ipfs.git#fb4bd2c5780810b8355356f2f683064008b60053"
 
 "@types/json-schema@^7.0.9":
   version "7.0.9"
@@ -540,10 +563,24 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
 
-"@types/node@*", "@types/node@>=13.7.0", "@types/node@^17.0.10":
+"@types/node@*", "@types/node@>=13.7.0":
   version "17.0.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.10.tgz#616f16e9d3a2a3d618136b1be244315d95bd7cab"
   integrity sha512-S/3xB4KzyFxYGCppyDt68yzBU9ysL88lSdIah4D6cptdcltc4NCPCAMc0+PCpg/lLIyC7IPvj2Z52OJWeIUkog==
+
+"@types/node@^17.0.13":
+  version "17.0.14"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.14.tgz#33b9b94f789a8fedd30a68efdbca4dbb06b61f20"
+  integrity sha512-SbjLmERksKOGzWzPNuW7fJM7fk3YXVTFiZWB/Hs99gwhk+/dnrQRPBQjPW9aO+fi1tAffi9PrwFvsmOKmDTyng==
+
+"@types/orbit-db@https://github.com/orbitdb/orbit-db-types.git":
+  version "1.0.1"
+  resolved "https://github.com/orbitdb/orbit-db-types.git#ed41369e64c054952c1e47505d598342a4967d4c"
+  dependencies:
+    "@types/elliptic" "^6.4.6"
+    "@types/events" "^1.2.0"
+    "@types/ipfs" "git+https://github.com/lukas2005/types-ipfs.git"
+    orbit-db "git+https://github.com/orbitdb/orbit-db.git"
 
 "@types/yargs-parser@*":
   version "20.2.1"
@@ -1834,6 +1871,13 @@ ipfs-log@^5.4.1:
     p-map "^4.0.0"
     p-whilst "^2.1.0"
 
+ipfs-pubsub-1on1@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/ipfs-pubsub-1on1/-/ipfs-pubsub-1on1-0.0.8.tgz#931809008b61218e7a882ec2e5666c04841b2055"
+  integrity sha512-f5pBfjkWSExrG1i63dZo7e1d0E+wN+WlHPQmU+7QP51q2zn2ycQReDbdPXP3JEi36/vqF6KAPB5SIFKyO0KgMA==
+  dependencies:
+    safe-buffer "~5.2.1"
+
 ipfs-pubsub-1on1@~0.0.6:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ipfs-pubsub-1on1/-/ipfs-pubsub-1on1-0.0.7.tgz#8c93c094c01b29012aab14694cfde0f525db955c"
@@ -2743,6 +2787,30 @@ orbit-db@^0.28.0:
   integrity sha512-lvqyG8fLKk8d35UqHGi3TVJUhR052MhXBaWahfvggcCBiHj8dSXBsQ5BkR+hK+vBIy0lKEQkhOFEKHhin8K1ig==
   dependencies:
     ipfs-pubsub-1on1 "~0.0.6"
+    is-electron "^2.2.0"
+    is-node "^1.0.2"
+    localstorage-down "^0.6.7"
+    logplease "^1.2.14"
+    multihashes "~3.0.1"
+    orbit-db-access-controllers "^0.3.2"
+    orbit-db-cache "~0.3.0"
+    orbit-db-counterstore "^1.12.1"
+    orbit-db-docstore "~1.12.0"
+    orbit-db-eventstore "~1.12.0"
+    orbit-db-feedstore "~1.12.0"
+    orbit-db-identity-provider "~0.3.0"
+    orbit-db-io "^1.0.1"
+    orbit-db-keystore "~0.3.0"
+    orbit-db-kvstore "~1.12.0"
+    orbit-db-pubsub "~0.6.0"
+    orbit-db-storage-adapter "~0.5.3"
+    orbit-db-store "^4.3.2"
+
+"orbit-db@git+https://github.com/orbitdb/orbit-db.git":
+  version "0.28.1"
+  resolved "git+https://github.com/orbitdb/orbit-db.git#726e667a4f452876271a3a40d22999268cc8a3e2"
+  dependencies:
+    ipfs-pubsub-1on1 "0.0.8"
     is-electron "^2.2.0"
     is-node "^1.0.2"
     localstorage-down "^0.6.7"


### PR DESCRIPTION
This PR adds a service class for interacting with the OrbitDB database containing all the emissions factors and lookup identifiers. Instructions for how to use the service:
* Move into the `utility-emissions-channel/docker-compose-setup/data` directory
* Load in the emissions factors and identifiers using the `src/dataLoader.ts` script
* Fetch or query for emissions factors using the methods provided by the service. An example for usage has been given in the `src/getData.ts` file. Please note that this file must be run with the current working directory being `data` and not `data/src`.