### PR TITLE
Add new README.md to lib folder

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,9 @@
+# lib
+
+This directory has common lirabries, including:
+
+* blockchain-gateway: 
+* data-common: 
+* emissions-data: 
+* oil-and-gas-data: 
+* supply-chain:


### PR DESCRIPTION
The PR adds a README.md to the lib folder. The actual link to it in the main README.md is broken, since no nested README exists. I'm not deep into the listed components yet, if someone can provide a meaningful description.

Signed-off-by: Karl Seidenfad <12004185+KSilkThread@users.noreply.github.com>